### PR TITLE
Refactor squad-server getPlayerBy* helpers

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -133,7 +133,7 @@ export default class Server extends EventEmitter {
   async getPlayerByAttribute(attribute, value, reload = true) {  
     const helper = () => {
       for (const player of this.players) {
-        if (player[attribute] === value) {
+        if (attribute in player && player[attribute] === value) {
           return player;
         }
       }

--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -117,50 +117,35 @@ export default class Server extends EventEmitter {
 
     this.emit(PLAYERS_UPDATED, this.players);
   }
-
-  async getPlayerByName(name, suffix = false) {
-    let matchingPlayers;
-
-    matchingPlayers = [];
-    for (const player of this.players) {
-      if (player[suffix ? 'suffix' : 'name'] !== name) continue;
-      matchingPlayers.push(player);
-    }
-
-    if (matchingPlayers.length === 0 && suffix === false) {
-      await this.updatePlayers();
-
-      matchingPlayers = [];
-      for (const player of this.players) {
-        if (player[suffix ? 'suffix' : 'name'] !== name) continue;
-        matchingPlayers.push(player);
-      }
-    }
-
-    if (matchingPlayers.length === 1) return matchingPlayers[0];
-    else return null;
+  
+  async getPlayerByName(name) {
+    return await this.getPlayerByAttribute('name', name);
   }
-
+  
+  async getPlayerBySuffix(suffix) {
+    return await this.getPlayerByAttribute('suffix', suffix);
+  }
+  
   async getPlayerBySteamID(steamID) {
-    let matchingPlayers;
-
-    matchingPlayers = [];
-    for (const player of this.players) {
-      if (player.steamID !== steamID) continue;
-      matchingPlayers.push(player);
-    }
-
-    if (matchingPlayers.length === 0) {
-      await this.updatePlayers();
-
-      matchingPlayers = [];
+    return await this.getPlayerByAttribute('steamID', steamID);
+  }
+  
+  async getPlayerByAttribute(attribute, value, reload = true) {  
+    const helper = () => {
       for (const player of this.players) {
-        if (player.steamID !== steamID) continue;
-        matchingPlayers.push(player);
+        if (player[attribute] === value) {
+          return player;
+        }
       }
     }
-
-    return matchingPlayers[0];
+    
+    let found = helper();
+    if (!found && reload) {
+      await this.updatePlayers();
+      helper(); 
+    }
+    
+    return found;
   }
 
   onLayerChange(info) {

--- a/squad-server/log-parser/rules/player-connected.js
+++ b/squad-server/log-parser/rules/player-connected.js
@@ -9,7 +9,7 @@ export default {
       raw: args[0],
       time: args[1],
       chainID: args[2],
-      player: await logParser.server.getPlayerByName(args[3], true)
+      player: await logParser.server.getPlayerBySuffix(args[3])
     };
 
     logParser.server.emit(PLAYER_CONNECTED, data);

--- a/squad-server/log-parser/rules/player-possess.js
+++ b/squad-server/log-parser/rules/player-possess.js
@@ -7,7 +7,7 @@ export default {
       raw: args[0],
       time: args[1],
       chainID: args[2],
-      player: await logParser.server.getPlayerByName(args[3], true),
+      player: await logParser.server.getPlayerBySuffix(args[3]),
       possessClassname: args[4]
     };
 

--- a/squad-server/log-parser/rules/player-un-possess.js
+++ b/squad-server/log-parser/rules/player-un-possess.js
@@ -7,7 +7,7 @@ export default {
       raw: args[0],
       time: args[1],
       chainID: args[2],
-      player: await logParser.server.getPlayerByName(args[3], true),
+      player: await logParser.server.getPlayerBySuffix(args[3]),
       switchPossess: false
     };
 


### PR DESCRIPTION
Makes the squad-server a bit more DRY by abstracting getPlayerBy* helpers into an getPlayerByAttribute helper.