### PR TITLE
Add ftpHost option

### DIFF
--- a/factory/templates/config-template.json
+++ b/factory/templates/config-template.json
@@ -10,6 +10,7 @@
     "logReaderMode": "tail",
     "logDir": "C:/path/to/squad/log/folder",
 
+    "ftpHost": null, // Set this if your FTP server does not listen on the same host as your Squad server
     "ftpPort": 21,
     "ftpUser": "FTP Username",
     "ftpPassword": "FTP Password",

--- a/squad-server/log-parser/log-readers/ftp.js
+++ b/squad-server/log-parser/log-readers/ftp.js
@@ -6,12 +6,12 @@ export default class TailLogReader {
   constructor(queueLine, options = {}) {
     if (typeof queueLine !== 'function')
       throw new Error('queueLine argument must be specified and be a function.');
-    if (!options.host) throw new Error('host argument must be specified.');
+    if (!options.ftpHost && !options.host) throw new Error('ftpHost or host argument must be specified.');
     if (!options.ftpUser) throw new Error('user argument must be specified.');
     if (!options.ftpPassword) throw new Error('password argument must be specified.');
 
     this.reader = new FTPTail({
-      host: options.host,
+      host: options.ftpHost ?? options.host,
       port: options.ftpPort || 21,
       user: options.ftpUser,
       password: options.ftpPassword,


### PR DESCRIPTION
Allow to use ftpHost if set, otherwise fall back to host.
This is a non-breaking change, to use it you will have to add `ftpHost` to your configuration.