### PR TITLE
SquadJS logging for MySQL

### DIFF
--- a/squad-server/factory.js
+++ b/squad-server/factory.js
@@ -114,7 +114,7 @@ export default class SquadServerFactory {
     }
 
     if (type === 'sequelize') {
-      let mergedConfig = Object.assign(connectorConfig, {logging: msg => Logger.verbose('MySQL', 1, msg)} );
+      let mergedConfig = Object.assign(connectorConfig, {logging: msg => Logger.verbose('Sequelize', 3, msg)} );
       const connector = new Sequelize(mergedConfig);
       await connector.authenticate();
       return connector;

--- a/squad-server/factory.js
+++ b/squad-server/factory.js
@@ -114,7 +114,8 @@ export default class SquadServerFactory {
     }
 
     if (type === 'sequelize') {
-      const connector = new Sequelize(connectorConfig);
+      let mergedConfig = Object.assign(connectorConfig, {logging: msg => Logger.verbose('MySQL', 1, msg)} );
+      const connector = new Sequelize(mergedConfig);
       await connector.authenticate();
       return connector;
     }


### PR DESCRIPTION
Sends Sequelize logging to Logger.verbose so that it is toggleable via SquadJS configs