### PR TITLE
Added toLowerCase to address case sensitive config

### DIFF
--- a/squad-server/plugins/chat-commands.js
+++ b/squad-server/plugins/chat-commands.js
@@ -38,7 +38,7 @@ export default class ChatCommands extends BasePlugin {
 
   async mount() {
     for (const command of this.options.commands) {
-      this.server.on(`CHAT_COMMAND:${command.command}`, async (data) => {
+      this.server.on(`CHAT_COMMAND:${command.command.toLowerCase()}`, async (data) => {
         if (command.ignoreChats.includes(data.chat)) return;
 
         if (command.type === 'broadcast') {


### PR DESCRIPTION
If a chat-command config has a command in uppercase it will never properly fire. Made the commands evaluate to lowercase so they are no longer case sensitive.