### PR TITLE
show active admins for !admin and warn those + simplify placeholder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,12 @@ Grafana (NOT YET WORKING WITH V2):
            <h6>Description</h6>
            <p>The color of the embed.</p>
            <h6>Default</h6>
-           <pre><code>16761867</code></pre></li></ul>
+           <pre><code>16761867</code></pre></li>
+<li><h4>warnInGameAdmins</h4>
+           <h6>Description</h6>
+           <p>Should in-game admins be warned after a players uses the command and should we tell how much admins are active in-game right now.</p>
+           <h6>Default</h6>
+           <pre><code>false</code></pre></li></ul>
         </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -474,7 +474,12 @@ Grafana (NOT YET WORKING WITH V2):
            <h6>Description</h6>
            <p>Should in-game admins be warned after a players uses the command and should we tell how much admins are active in-game right now.</p>
            <h6>Default</h6>
-           <pre><code>false</code></pre></li></ul>
+           <pre><code>false</code></pre></li>
+<li><h4>showInGameAdmins</h4>
+           <h6>Description</h6>
+           <p>Should players know how much in-game admins there are active/online?</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li></ul>
         </details>
 
 <details>

--- a/config.json
+++ b/config.json
@@ -91,7 +91,8 @@
       "command": "admin",
       "pingGroups": [],
       "pingDelay": 60000,
-      "color": 16761867
+      "color": 16761867,
+      "warnInGameAdmins": false
     },
     {
       "plugin": "DiscordChat",

--- a/config.json
+++ b/config.json
@@ -92,7 +92,8 @@
       "pingGroups": [],
       "pingDelay": 60000,
       "color": 16761867,
-      "warnInGameAdmins": false
+      "warnInGameAdmins": false,
+      "showInGameAdmins": true
     },
     {
       "plugin": "DiscordChat",

--- a/squad-server/plugins/discord-admin-request.js
+++ b/squad-server/plugins/discord-admin-request.js
@@ -136,12 +136,11 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
 
     const admins = await this.server.getAdminsWithPermission('canseeadminchat');
     let amountAdmins = 0;
-    if (this.options.warnInGameAdmins) {
-      for (const player of this.server.players) {
-        if (!admins.includes(player.steamID)) continue;
-        amountAdmins++;
+    for (const player of this.server.players) {
+      if (!admins.includes(player.steamID)) continue;
+      amountAdmins++;
+      if (this.options.warnInGameAdmins)
         await this.server.rcon.warn(player.steamID, `[${info.player.name}] - ${info.message}`);
-      }
     }
 
     if (amountAdmins === 0 && this.options.showInGameAdmins)

--- a/squad-server/plugins/discord-admin-request.js
+++ b/squad-server/plugins/discord-admin-request.js
@@ -142,29 +142,24 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
         amountAdmins++;
         await this.server.rcon.warn(player.steamID, `[${info.player.name}] - ${info.message}`);
       }
+    }
 
-      if (amountAdmins === 0 && this.options.showInGameAdmins)
-        await this.server.rcon.warn(
-          info.player.steamID,
-          `There are no in-game admins, however an admin has been notified via discord, please wait for us to get back to you.`
-        );
-      else if (this.options.showInGameAdmins)
-        await this.server.rcon.warn(
-          info.player.steamID,
-          `There ${amountAdmins > 1 ? 'are' : 'is'} ${amountAdmins} in-game admin${
-            amountAdmins > 1 ? 's' : ''
-          }. Please wait for us to get back to you.`
-        );
-      else
-        await this.server.rcon.warn(
-          info.player.steamID,
-          `An admin has been notified, please wait for us to get back to you.`
-        );
-    } else {
+    if (amountAdmins === 0 && this.options.showInGameAdmins)
       await this.server.rcon.warn(
         info.player.steamID,
-        `An admin has been notified, please wait for us to get back to you.`
+        `There are no in-game admins, however, an admin has been notified via Discord. Please wait for us to get back to you.`
       );
-    }
+    else if (this.options.showInGameAdmins)
+      await this.server.rcon.warn(
+        info.player.steamID,
+        `There ${amountAdmins > 1 ? 'are' : 'is'} ${amountAdmins} in-game admin${
+          amountAdmins > 1 ? 's' : ''
+        }. Please wait for us to get back to you.`
+      );
+    else
+      await this.server.rcon.warn(
+        info.player.steamID,
+        `An admin has been notified. Please wait for us to get back to you.`
+      );
   }
 }

--- a/squad-server/plugins/discord-admin-request.js
+++ b/squad-server/plugins/discord-admin-request.js
@@ -143,7 +143,7 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
         await this.server.rcon.warn(player.steamID, `[${info.player.name}] - ${info.message}`);
       }
 
-      if (amountAdmins === 0)
+      if (amountAdmins === 0 && this.options.showInGameAdmins)
         await this.server.rcon.warn(
           info.player.steamID,
           `There are no in-game admins, however an admin has been notified via discord, please wait for us to get back to you.`

--- a/squad-server/plugins/discord-placeholder.js
+++ b/squad-server/plugins/discord-placeholder.js
@@ -36,8 +36,6 @@ export default class DiscordPlaceholder extends BasePlugin {
   constructor(server, options, connectors) {
     super(server, options, connectors);
 
-    this.escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
     this.onMessage = this.onMessage.bind(this);
   }
 
@@ -52,8 +50,7 @@ export default class DiscordPlaceholder extends BasePlugin {
   async onMessage(message) {
     if (message.author.bot) return;
     if (message.channel.id !== this.options.channelID) return;
-    const prefixRegex = new RegExp(`^(${this.escapeRegex(this.options.command)})\\s*`);
-    if (!prefixRegex.test(message.content)) return;
+    if (!message.content.startsWith(this.options.command)) return;
     await message.channel.send('Placeholder.');
   }
 }


### PR DESCRIPTION
- Simplify the placeholder plugin I did push before
- Add `warnInGameAdmins` for the `discord-admin-request` plugin.
  - Checks if there are online admins in-game. If there are any online in-game admins the plugins warns the admins with the name of the player and the message. Meanwhile respondig to the player with a message including the amount of active admins.(See screenshot) If there are no active admins, it will show a message saying there are noone but that admins were warned on discord. This will still always do it's default function, warn the admins on discord. But did add just this so in-game admins life is going to be easier by not always switching screens to check if someone did use the command. This will also make the trigger function from BM useless since it is way more effective than a notifaction on your phone 👍  (BM triggers are not free, this is.)
  
    - Please note the above warning is in Turkish, because I did test this on a Turkish server. It is basicly the admin testing the !admin function. This is also why you see 2 warnings, one of them is supposed to go to the admin (the top warning) and the other one to the player requesting it (the bottom warning).
    ![image](https://user-images.githubusercontent.com/25463237/110167375-f709b480-7df5-11eb-8727-e83e5e6c5124.png)

This will fix : https://github.com/Thomas-Smyth/SquadJS/issues/57  and https://github.com/Thomas-Smyth/SquadJS/issues/63