### PR TITLE
Fix player connection event.

### DIFF
--- a/squad-server/log-parser/steamid-connected.js
+++ b/squad-server/log-parser/steamid-connected.js
@@ -1,6 +1,7 @@
 export default {
-  regex: /^\[([0-9.:-]+)]\[([ 0-9]*)]LogEasyAntiCheatServer: \[[0-9:]+]\[[A-z]+]\[EAC Server] \[Info]\[RegisterClient] Client: ([A-z0-9]+) PlayerGUID: ([0-9]{17}) PlayerIP: [0-9]{17} OwnerGUID: [0-9]{17} PlayerName: (.+)/,
+  regex: /^\[([0-9.:-]+)]\[([ 0-9]*)]LogEasyAntiCheatServer: \[[0-9:]+] \[[A-z]+] \[EAC Server] \[Info] \[RegisterClient] Client: ([A-z0-9]+) PlayerGUID: ([0-9]{17}) PlayerIP: [0-9]{17} OwnerGUID: [0-9]{17} PlayerName: (.+)/,
   onMatch: async (args, logParser) => {
     logParser.eventStore['steamid-connected'] = args[4];
   }
 };
+


### PR DESCRIPTION
It would appear the Squad log added some spaces, which was messing up with the regex for steamid-connected, which in return stopped player-connected from working as well. 

This appears to fix the issue, regex now matches the line in the log.