### PR TITLE
Add 'SQUAD_CREATED' event.

### DIFF
--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -14,6 +14,7 @@ import PlayerWounded from './player-wounded.js';
 import RoundWinner from './round-winner.js';
 import ServerTickRate from './server-tick-rate.js';
 import SteamIDConnected from './steamid-connected.js';
+import SquadCreated from './squad-created.js';
 
 export default class SquadLogParser extends LogParser {
   constructor(options) {
@@ -35,7 +36,8 @@ export default class SquadLogParser extends LogParser {
       PlayerWounded,
       RoundWinner,
       ServerTickRate,
-      SteamIDConnected
+      SteamIDConnected,
+      SquadCreated
     ];
   }
 }

--- a/squad-server/log-parser/squad-created.js
+++ b/squad-server/log-parser/squad-created.js
@@ -7,8 +7,8 @@ export default {
       chainID: args[2],
       playerName: args[3],
       playerSteamID: args[4],
-      squadNumber: args[5],
-      squadID: args[6],
+      squadID: args[5],
+      squadName: args[6],
       teamName: args[7]
     };
 	

--- a/squad-server/log-parser/squad-created.js
+++ b/squad-server/log-parser/squad-created.js
@@ -1,0 +1,17 @@
+export default {
+  regex: /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: (.+) \(Steam ID: ([0-9]{17})\) has created Squad (\d+) \(Squad Name: (.+)\) on (.+)/,
+  onMatch: async (args, logParser) => {
+    const data = {
+      raw: args[0],
+      time: args[1],
+      chainID: args[2],
+      playerName: args[3],
+      playerSteamID: args[4],
+      squadNumber: args[5],
+      squadID: args[6],
+      teamName: args[7]
+    };
+	
+    logParser.emit('SQUAD_CREATED', data);
+  }
+};

--- a/squad-server/plugins/discord-squad-created.js
+++ b/squad-server/plugins/discord-squad-created.js
@@ -1,0 +1,81 @@
+import DiscordBasePlugin from './discord-base-plugin.js';
+
+export default class DiscordSquadCreated extends DiscordBasePlugin {
+  static get description() {
+    return 'The <code>SquadCreated</code> plugin will log Squad Creation events to a Discord channel.';
+  }
+
+  static get defaultEnabled() {
+    return false;
+  }
+
+  static get optionsSpecification() {
+    return {
+      ...DiscordBasePlugin.optionsSpecification,
+      channelID: {
+        required: true,
+        description: 'The ID of the channel to log Squad Creation events to.',
+        default: '',
+        example: '667741905228136459'
+      },
+      color: {
+        required: false,
+        description: 'The color of the embed.',
+        default: 16761867
+      },
+      useEmbed:{
+        required: false,
+        description: `Send message as Embed`,
+        default: true
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+
+    this.onSquadCreated = this.onSquadCreated.bind(this);
+  }
+
+  async mount() {
+    this.server.on('SQUAD_CREATED', this.onSquadCreated);
+  }
+
+  async unmount() {
+    this.server.removeEventListener('SQUAD_CREATED', this.onSquadCreated);
+  }
+
+  async onSquadCreated(info) {
+
+    if(this.options.useEmbed){
+
+        await this.sendDiscordMessage({
+            embed: {
+                title: `Squad Created`,
+                color: this.options.color,
+                fields: [
+                {
+                    name: 'Player',
+                    value: info.playerName,
+                    inline: true
+                },
+                {
+                    name: 'Team',
+                    value: info.teamName,
+                    inline: true
+                },
+                {
+                    name: 'Squad Number & Squad Name',
+                    value: `${info.squadID} : ${info.squadName}`
+                }
+                ],
+                timestamp: info.time.toISOString()
+            }
+        });
+
+    } else {
+
+        await this.sendDiscordMessage(` \`\`\`Player: ${info.playerName}\n created Squad ${info.squadID} : ${info.squadName}\n on ${info.teamName}\`\`\` `)
+    }
+  }
+}


### PR DESCRIPTION
Initial Attempt at parsing Squad Created Log line.

Should match and fire "Squad_Created" event for consuming elsewhere. Matches lines similar to those below

[2021.06.25-21.00.27:067][883]LogSquad: ect0s (Steam ID: 76561198129106227) has created Squad 1 (Squad Name: Squad 1) on United States Army