### PR TITLE
Add PLAYER_AUTO_KICKED event to the broadcast-able socket.io messages

### DIFF
--- a/squad-server/plugins/socket-io-api.js
+++ b/squad-server/plugins/socket-io-api.js
@@ -25,7 +25,8 @@ const eventsToBroadcast = [
   'PLAYER_SQUAD_CHANGE',
   'UPDATED_PLAYER_INFORMATION',
   'UPDATED_LAYER_INFORMATION',
-  'UPDATED_A2S_INFORMATION'
+  'UPDATED_A2S_INFORMATION',
+  'PLAYER_AUTO_KICKED'
 ];
 
 export default class SocketIOAPI extends BasePlugin {


### PR DESCRIPTION
First things first; 
I know I need to rewrite this outside of the plugins but I plan to make it after my vacation 😢

As side note I did add this since I was writing an guide-like repo so people could check on how to use this damn socketIO thing 😄