### PR TITLE
Add SQUAD_CREATED to list of events emitted by Socket.io

### DIFF
--- a/squad-server/plugins/socket-io-api.js
+++ b/squad-server/plugins/socket-io-api.js
@@ -29,7 +29,8 @@ const eventsToBroadcast = [
   'PLAYER_AUTO_KICKED',
   'PLAYER_WARNED',
   'PLAYER_KICKED',
-  'PLAYER_BANNED'
+  'PLAYER_BANNED',
+  'SQUAD_CREATED'
 ];
 
 export default class SocketIOAPI extends BasePlugin {


### PR DESCRIPTION
To be utilized via the SocketIO. (mainly SquadStatsJSPRO tbh)