### PR TITLE
Fix missing teamkill event on instakill

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -244,6 +244,7 @@ export default class SquadServer extends EventEmitter {
 
     this.logParser.on('PLAYER_DIED', async (data) => {
       data.victim = await this.getPlayerByName(data.victimName);
+      data.attacker = await this.getPlayerByName(data.attackerName);
 
       if (data.victim && data.attacker)
         data.teamkill =
@@ -254,6 +255,10 @@ export default class SquadServer extends EventEmitter {
       delete data.attackerName;
 
       this.emit('PLAYER_DIED', data);
+
+      if (data.teamkill) {
+        this.emit('TEAMKILL', data);
+      }
     });
 
     this.logParser.on('PLAYER_REVIVED', async (data) => {


### PR DESCRIPTION
When a player got instakilled, due to large caliber or during grayed-out stage after revival, the teamkill event was not triggered.

Example from the logs:
```logs
[2021.10.31-00.38.35:319][ 83]LogSquad: Player:Victim ActualDamage=900.000000 from Attacker caused by BP_BTR82A_RUS_2A72_AP_C_2147479210
[2021.10.31-00.38.35:319][ 83]LogSquadTrace: [DedicatedServer]ASQSoldier::Die(): Player:Victim KillingDamage=900.000000 from BP_PlayerController_C_2147481608 caused by BP_BTR82A_RUS_2A72_AP_C_2147479210
```