### PR TITLE
ttVote Plugin and the Rcon Methods it requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,9 +938,10 @@ Grafana:
           <h2>ttVote</h2>
           <p>NaN * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
  Once a vote is in progress it either must end, or be canceled before starting another vote 
-During a vote, every 30 seconds the options are Broadcast to the server 
+ During a vote, every 30 seconds the options are Broadcast to the server 
 Automatically Sets Nextmap
-Players vote via sending a matching number in any chat
+ Players vote via sending a matching number in any chat 
+
 
 Player Commands:
  * <code><layer number></code> - Vote for a layer using the layer number.

--- a/README.md
+++ b/README.md
@@ -947,10 +947,10 @@ Grafana:
  * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes.  Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map 
  * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options
  * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
-Once a vote is in progress it either must end, or be canceled before starting another vote 
-During a vote, every 30 seconds the options are Broadcast to the server 
-Automatically Sets Nextmap 
-Players vote via sending a matching number in any chat 
+Once a vote is in progress it either must end, or be canceled before starting another vote
+During a vote, every 30 seconds the options are Broadcast to the server
+Automatically Sets Nextmap
+Players vote via sending a matching number in any chat
  
 
 Player Commands:
@@ -959,9 +959,9 @@ Player Commands:
 
 Admin Commands (Admin Chat Only):
  * <code>!mapvote</code> - Start a new map vote with 3 random maps.
- * <code>!mapvote aas inv raas </code> - search via game mode
- * <code>!mapvote yeho:raas narva:tc goro:inv</code> - layer:mode, can stack deeper for specifc versions
- * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)
+ * <code>!mapvote aas inv raas </code> Example GameMode search
+ * <code>!mapvote yeho:raas narva:tc goro:inv</code> Example Layer Search
+ * <code>!vote option1 option2 option 3</code> - Simple vote for anything besides maps (Admin must set whatever options)
  * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots
  * <code>!endvote</code> - End a vote Early, Totalling the ballots.
 </p>
@@ -985,11 +985,17 @@ Admin Commands (Admin Chat Only):
            <pre><code>120</code></pre>
 <li><h4>ignoreChats (Required)</h4>
            <h6>Description</h6>
-           <p>The chat channels to ignore.</p>
+           <p>The chat channels to ignore for reading commands</p>
            <h6>Default</h6>
-           <pre><code>null</code></pre></li><h6>Example</h6>
            <pre><code>[
-  "ChatAll"
+  "ChatAll",
+  "ChatSquad",
+  "ChatTeam"
+]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "ChatAll",
+  "ChatSquad",
+  "ChatTeam"
 ]</code></pre>
 <li><h4>blacklist (Required)</h4>
            <h6>Description</h6>

--- a/README.md
+++ b/README.md
@@ -947,12 +947,12 @@ Grafana:
   * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
  Once a vote is in progress it either must end, or be canceled before starting another vote 
  During a vote, every 30 seconds the options are Broadcast to the server 
-Automatically Sets Nextmap
- Players vote via sending a matching number in any chat 
-
+Automatically Sets Nextmap 
+Players vote via sending a matching number in any chat 
+ 
 
 Player Commands:
- * <code><layer number></code> - Vote for a layer using the layer number.
+ * <code>Number</code> - Vote for a layer using the layer number.
 
 
 Admin Commands (Admin Chat Only):

--- a/README.md
+++ b/README.md
@@ -933,6 +933,121 @@ Grafana:
            <pre><code>randomize</code></pre></li></ul>
         </details>
 
+<details>
+          <summary>ttVote</summary>
+          <h2>ttVote</h2>
+          <p>The <code>tt-vote</code> plugin provides complex voting functionality:
+
+
+ * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting 
+ * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply 
+ * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. 
+ * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable 
+ * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF 
+ * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes.  Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map 
+ * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options
+ * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
+Once a vote is in progress it either must end, or be canceled before starting another vote 
+During a vote, every 30 seconds the options are Broadcast to the server 
+Automatically Sets Nextmap 
+Players vote via sending a matching number in any chat 
+ 
+
+Player Commands:
+ * <code>Number</code> - Vote for a layer using the layer number.
+
+
+Admin Commands (Admin Chat Only):
+ * <code>!mapvote</code> - Start a new map vote with 3 random maps.
+ * <code>!mapvote aas inv raas </code> 
+ * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.
+ * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)
+ * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots
+ * <code>!endvote</code> - End a vote Early, Totalling the ballots.
+</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log vote broadcasts to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>voteTime</h4>
+           <h6>Description</h6>
+           <p>The amount of time for players to vote in seconds.</p>
+           <h6>Default</h6>
+           <pre><code>null</code></pre></li><h6>Example</h6>
+           <pre><code>120</code></pre>
+<li><h4>ignoreChats (Required)</h4>
+           <h6>Description</h6>
+           <p>The chat channels to ignore.</p>
+           <h6>Default</h6>
+           <pre><code>null</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "ChatAll"
+]</code></pre>
+<li><h4>blacklist (Required)</h4>
+           <h6>Description</h6>
+           <p>Layers, Modes, and Words to remove</p>
+           <h6>Default</h6>
+           <pre><code>[
+  "insurgency",
+  "jensens",
+  "destruction"
+]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "caf_",
+  "insurgency",
+  "jensens",
+  "destruction"
+]</code></pre>
+<li><h4>whitelist (Required)</h4>
+           <h6>Description</h6>
+           <p>Layers, Modes, and Words to restrict options to</p>
+           <h6>Default</h6>
+           <pre><code>[]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "RAAS"
+]</code></pre>
+<li><h4>layerHistoryLimit (Required)</h4>
+           <h6>Description</h6>
+           <p>The set of previous maps to exclude layers from the next vote, stops repeated short rotations</p>
+           <h6>Default</h6>
+           <pre><code>0</code></pre></li><h6>Example</h6>
+           <pre><code>2</code></pre>
+<li><h4>allowMultipleCAF</h4>
+           <h6>Description</h6>
+           <p>if each set of layer options should attempt to only have a single CAF layer</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li><h6>Example</h6>
+           <pre><code>true</code></pre>
+<li><h4>disallowRepeatedInvasion</h4>
+           <h6>Description</h6>
+           <p>Attempt to limit Invasion if recently played in map History</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li><h6>Example</h6>
+           <pre><code>true</code></pre>
+<li><h4>layerPrefixes (Required)</h4>
+           <h6>Description</h6>
+           <p>Map Prefixes from Mods or DLC, used to filter out base maps</p>
+           <h6>Default</h6>
+           <pre><code>[
+  "CAF_"
+]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "CAF_",
+  "BAL_",
+  "GC_",
+  "HLP_",
+  "HRR_"
+]</code></pre></ul>
+        </details>
+
 <br>
 
 ## Statement on Accuracy

--- a/README.md
+++ b/README.md
@@ -936,8 +936,7 @@ Grafana:
 <details>
           <summary>ttVote</summary>
           <h2>ttVote</h2>
-          <p>The <code>tt-vote</code> plugin provides complex voting functionality. 
-features:
+          <p>The <code>tt-vote</code> plugin provides complex voting functionality:
 
 
  * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting 

--- a/README.md
+++ b/README.md
@@ -936,7 +936,10 @@ Grafana:
 <details>
           <summary>ttVote</summary>
           <h2>ttVote</h2>
-          <p>The <code>tt-vote</code> plugin provides complex voting functionality: 
+          <p>The <code>tt-vote</code> plugin provides complex voting functionality. 
+features:
+
+
  * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting 
  * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply 
  * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. 

--- a/README.md
+++ b/README.md
@@ -933,6 +933,110 @@ Grafana:
            <pre><code>randomize</code></pre></li></ul>
         </details>
 
+<details>
+          <summary>ttVote</summary>
+          <h2>ttVote</h2>
+          <p>NaN * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
+ Once a vote is in progress it either must end, or be canceled before starting another vote 
+During a vote, every 30 seconds the options are Broadcast to the server 
+Automatically Sets Nextmap
+Players vote via sending a matching number in any chat
+
+Player Commands:
+ * <code><layer number></code> - Vote for a layer using the layer number.
+
+
+Admin Commands (Admin Chat Only):
+ * <code>!mapvote</code> - Start a new map vote with 3 random maps.
+ * <code>!mapvote aas inv raas </code>- 
+ * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.
+ * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)
+ * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots
+ * <code>!endvote</code> - End a vote Early, Totalling the ballots.
+</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log vote broadcasts to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>voteTime</h4>
+           <h6>Description</h6>
+           <p>The amount of time for players to vote in seconds.</p>
+           <h6>Default</h6>
+           <pre><code>null</code></pre></li><h6>Example</h6>
+           <pre><code>120</code></pre>
+<li><h4>ignoreChats (Required)</h4>
+           <h6>Description</h6>
+           <p>The chat channels to ignore.</p>
+           <h6>Default</h6>
+           <pre><code>null</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "ChatAll"
+]</code></pre>
+<li><h4>blacklist (Required)</h4>
+           <h6>Description</h6>
+           <p>Layers, Modes, and Words to remove</p>
+           <h6>Default</h6>
+           <pre><code>[
+  "insurgency",
+  "jensens",
+  "destruction"
+]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "caf_",
+  "insurgency",
+  "jensens",
+  "destruction"
+]</code></pre>
+<li><h4>whitelist (Required)</h4>
+           <h6>Description</h6>
+           <p>Layers, Modes, and Words to restrict options to</p>
+           <h6>Default</h6>
+           <pre><code>[]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "RAAS"
+]</code></pre>
+<li><h4>layerHistoryLimit (Required)</h4>
+           <h6>Description</h6>
+           <p>The set of previous maps to exclude layers from the next vote, stops repeated short rotations</p>
+           <h6>Default</h6>
+           <pre><code>0</code></pre></li><h6>Example</h6>
+           <pre><code>2</code></pre>
+<li><h4>allowMultipleCAF</h4>
+           <h6>Description</h6>
+           <p>if each set of layer options should attempt to only have a single CAF layer</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li><h6>Example</h6>
+           <pre><code>true</code></pre>
+<li><h4>disallowRepeatedInvasion</h4>
+           <h6>Description</h6>
+           <p>Attempt to limit Invasion if recently played in map History</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li><h6>Example</h6>
+           <pre><code>true</code></pre>
+<li><h4>layerPrefixes (Required)</h4>
+           <h6>Description</h6>
+           <p>Map Prefixes from Mods or DLC, used to filter out base maps</p>
+           <h6>Default</h6>
+           <pre><code>[
+  "CAF_"
+]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "CAF_",
+  "BAL_",
+  "GC_",
+  "HLP_",
+  "HRR_"
+]</code></pre></ul>
+        </details>
+
 <br>
 
 ## Statement on Accuracy

--- a/README.md
+++ b/README.md
@@ -936,7 +936,15 @@ Grafana:
 <details>
           <summary>ttVote</summary>
           <h2>ttVote</h2>
-          <p>NaN * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
+          <p>The <code>tt-vote</code> plugin provides complex voting functionality.
+ * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting
+  * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply
+  * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map.
+  * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable
+  * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF
+  * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes.  Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map
+  * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options
+  * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
  Once a vote is in progress it either must end, or be canceled before starting another vote 
  During a vote, every 30 seconds the options are Broadcast to the server 
 Automatically Sets Nextmap

--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ Grafana:
 <details>
           <summary>ttVote</summary>
           <h2>ttVote</h2>
-          <p>The <code>tt-vote</code> plugin provides complex voting functionality. 
+          <p>The <code>tt-vote</code> plugin provides complex voting functionality: 
  * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting 
  * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply 
  * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. 

--- a/README.md
+++ b/README.md
@@ -936,17 +936,17 @@ Grafana:
 <details>
           <summary>ttVote</summary>
           <h2>ttVote</h2>
-          <p>The <code>tt-vote</code> plugin provides complex voting functionality.
- * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting
-  * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply
-  * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map.
-  * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable
-  * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF
-  * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes.  Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map
-  * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options
-  * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
- Once a vote is in progress it either must end, or be canceled before starting another vote 
- During a vote, every 30 seconds the options are Broadcast to the server 
+          <p>The <code>tt-vote</code> plugin provides complex voting functionality. 
+ * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting 
+ * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply 
+ * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. 
+ * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable 
+ * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF 
+ * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes.  Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map 
+ * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options
+ * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options
+Once a vote is in progress it either must end, or be canceled before starting another vote 
+During a vote, every 30 seconds the options are Broadcast to the server 
 Automatically Sets Nextmap 
 Players vote via sending a matching number in any chat 
  
@@ -957,7 +957,7 @@ Player Commands:
 
 Admin Commands (Admin Chat Only):
  * <code>!mapvote</code> - Start a new map vote with 3 random maps.
- * <code>!mapvote aas inv raas </code>- 
+ * <code>!mapvote aas inv raas </code> 
  * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.
  * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)
  * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots

--- a/README.md
+++ b/README.md
@@ -959,8 +959,8 @@ Player Commands:
 
 Admin Commands (Admin Chat Only):
  * <code>!mapvote</code> - Start a new map vote with 3 random maps.
- * <code>!mapvote aas inv raas </code> 
- * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.
+ * <code>!mapvote aas inv raas </code> - search via game mode
+ * <code>!mapvote yeho:raas narva:tc goro:inv</code> - layer:mode, can stack deeper for specifc versions
  * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)
  * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots
  * <code>!endvote</code> - End a vote Early, Totalling the ballots.

--- a/config.json
+++ b/config.json
@@ -231,6 +231,26 @@
       "plugin": "TeamRandomizer",
       "enabled": true,
       "command": "randomize"
+    },
+    {
+      "plugin": "ttVote",
+      "enabled": true,
+      "discordClient": "discord",
+      "channelID": "",
+      "voteTime": null,
+      "ignoreChats": null,
+      "blacklist": [
+        "insurgency",
+        "jensens",
+        "destruction"
+      ],
+      "whitelist": [],
+      "layerHistoryLimit": 0,
+      "allowMultipleCAF": true,
+      "disallowRepeatedInvasion": true,
+      "layerPrefixes": [
+        "CAF_"
+      ]
     }
   ],
   "logger": {

--- a/config.json
+++ b/config.json
@@ -238,7 +238,11 @@
       "discordClient": "discord",
       "channelID": "",
       "voteTime": null,
-      "ignoreChats": null,
+      "ignoreChats": [
+        "ChatAll",
+        "ChatSquad",
+        "ChatTeam"
+      ],
       "blacklist": [
         "insurgency",
         "jensens",

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -10,13 +10,13 @@ export default class ttVote extends DiscordBasePlugin {
         ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable\n ' +
         ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF\n ' +
         ' * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes. ' +
-        'Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map\n',
+        ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map\n ',
       +' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n ' +
         ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n ' +
-        'Once a vote is in progress it either must end, or be canceled before starting another vote \n' +
+        'Once a vote is in progress it either must end, or be canceled before starting another vote \n ' +
         'During a vote, every 30 seconds the options are Broadcast to the server \n' +
-        'Automatically Sets Nextmap\n' +
-        'Players vote via sending a matching number in any chat' +
+        'Automatically Sets Nextmap\n ' +
+        'Players vote via sending a matching number in any chat \n' +
         '\n\n' +
         'Player Commands:\n' +
         ' * <code><layer number></code> - Vote for a layer using the layer number.\n' +

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -1,0 +1,488 @@
+import DiscordBasePlugin from './discord-base-plugin.js';
+
+export default class ttVote extends DiscordBasePlugin {
+  static get description() {
+    return (
+      'The <code>tt-vote</code> plugin provides complex voting functionality.\n' +
+        ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting\n ' +
+        ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply\n ' +
+        ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map.\n ' +
+        ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable\n ' +
+        ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF\n ' +
+        ' * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes. ' +
+        'Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map\n',
+      +' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n ' +
+        ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n ' +
+        'Once a vote is in progress it either must end, or be canceled before starting another vote \n' +
+        'During a vote, every 30 seconds the options are Broadcast to the server \n' +
+        'Automatically Sets Nextmap\n' +
+        'Players vote via sending a matching number in any chat' +
+        '\n\n' +
+        'Player Commands:\n' +
+        ' * <code><layer number></code> - Vote for a layer using the layer number.\n' +
+        '\n\n' +
+        'Admin Commands (Admin Chat Only):\n' +
+        ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
+        ' * <code>!mapvote aas inv raas </code>- \n' +
+        ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.\n' +
+        ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
+        ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +
+        ' * <code>!endvote</code> - End a vote Early, Totalling the ballots.\n'
+    );
+  }
+
+  static get defaultEnabled() {
+    return true;
+  }
+
+  static get optionsSpecification() {
+    return {
+      ...DiscordBasePlugin.optionsSpecification,
+      channelID: {
+        required: true,
+        description: 'The ID of the channel to log vote broadcasts to.',
+        default: '',
+        example: '667741905228136459'
+      },
+      voteTime: {
+        required: false,
+        description: 'The amount of time for players to vote in seconds.',
+        default: null,
+        example: 120
+      },
+      ignoreChats: {
+        required: true,
+        description: 'The chat channels to ignore.',
+        default: null,
+        example: ['ChatAll']
+      },
+      blacklist: {
+        required: true,
+        description: 'Layers, Modes, and Words to remove',
+        default: ['insurgency', 'jensens', 'destruction'],
+        example: ['caf_', 'insurgency', 'jensens', 'destruction']
+      },
+      whitelist: {
+        required: true,
+        description: 'Layers, Modes, and Words to restrict options to',
+        default: [],
+        example: ['RAAS']
+      },
+      layerHistoryLimit: {
+        required: true,
+        description:
+          'The set of previous maps to exclude layers from the next vote, stops repeated short rotations',
+        default: 0,
+        example: 2
+      },
+      allowMultipleCAF: {
+        required: false,
+        description: 'if each set of layer options should attempt to only have a single CAF layer',
+        default: true,
+        example: true
+      },
+      disallowRepeatedInvasion: {
+        required: false,
+        description: 'Attempt to limit Invasion if recently played in map History',
+        default: true,
+        example: true
+      },
+      layerPrefixes: {
+        required: true,
+        description: 'Map Prefixes from Mods or DLC, used to filter out base maps',
+        default: ['CAF_'],
+        example: ['CAF_', 'BAL_', 'GC_', 'HLP_', 'HRR_']
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+
+    this.onChatMessage = this.onChatMessage.bind(this);
+    this.onNewGame = this.onNewGame.bind(this);
+    this.tallyVotes = this.tallyVotes.bind(this);
+    this.callVote = this.callVote.bind(this);
+    this.parseVoteParams = this.parseVoteParams.bind(this);
+    this.getLayerOptions = this.getLayerOptions.bind(this);
+    this.checkAndRemovePrefix = this.checkAndRemovePrefix.bind(this);
+    this.clearVote = this.clearVote.bind(this);
+    this.mapvote = false;
+    this.voteInProgress = false;
+    this.ballotBox = new Map();
+    this.voteOptions = [];
+  }
+
+  async mount() {
+    this.server.on('CHAT_MESSAGE', this.onChatMessage);
+    this.server.on('NEW_GAME', this.onNewGame);
+    // NEW GAME is unreliable with mods.
+  }
+
+  async unmount() {
+    this.server.on('CHAT_MESSAGE', this.onChatMessage);
+    this.server.on('NEW_GAME', this.onNewGame);
+  }
+
+  async onNewGame(info) {
+    this.clearVote();
+    clearInterval(this.voteBroadcast);
+    clearInterval(this.voteTimeout);
+  }
+
+  async onChatMessage(info) {
+    this.info = info;
+
+    // EXIT IF VOTE IN PROGRESS
+    if (
+      this.voteInProgress &&
+      (info.message.toLowerCase().startsWith('!vote') ||
+        info.message.toLowerCase().startsWith('!mapvote')) &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      await this.server.rcon.warn(
+        info.steamID,
+        'Vote already in progress. Type !cancelvote or !endvote to end the vote early'
+      );
+      return;
+    }
+
+    // START A VOTE
+    if (
+      !this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!vote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      this.voteOptions = info.message.slice(6, info.message.length).match(/[A-z0-9:]+/g);
+      if (!this.voteOptions || this.voteOptions.length < 2) {
+        await this.server.rcon.warn(info.steamID, 'Please input at least two vote options.');
+        return;
+      }
+
+      this.callVote(this.voteOptions);
+    }
+
+    // Start a mapvote
+    if (
+      !this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!mapvote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      // Default case of !mapvote with no args
+      if (info.message.toLowerCase() === '!mapvote') {
+        this.mapvote = true;
+        this.voteOptions = await this.getLayerOptions();
+        await this.callVote(this.voteOptions);
+        return;
+      }
+
+      // Otherwise...
+      const params = this.parseVoteParams(
+        info.message
+          .slice(9, info.message.length)
+          .toLowerCase()
+          .match(/[a-z0-9:]+/g)
+      );
+      if (params.length < 2 || params.length > 4) {
+        await this.server.rcon.warn(info.steamID, 'Please input between 2-4 vote options.');
+        return;
+      }
+      this.voteOptions = await this.getLayerOptions(params);
+      if (params.length !== this.voteOptions.length) {
+        await this.server.rcon.warn(
+          info.steamID,
+          'Vote Cancelled, perhaps one of maps/modes you tried to select was recently played or blacklisted?'
+        );
+        return;
+      }
+      this.mapvote = true;
+      await this.callVote(this.voteOptions);
+    }
+
+    // End a vote, counting totals
+    if (
+      this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!endvote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      clearTimeout(this.voteTimeout);
+      clearInterval(this.voteBroadcast);
+      await this.tallyVotes();
+      return;
+    }
+    // Cancel a Vote, No Totals
+    if (
+      this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!cancelvote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      this.clearVote();
+      clearTimeout(this.voteTimeout);
+      clearInterval(this.voteBroadcast);
+
+      await this.server.rcon.warn(info.steamID, 'Vote Cancelled');
+      await this.server.rcon.broadcast(`Server: Vote Has Been Canceled by an Admin`);
+
+      return;
+    }
+
+    // PLAYER VOTES HERE
+    if (this.voteInProgress && info.message.match(/^[0-9]+/)) {
+      const optionIndex = parseInt(info.message) - 1;
+      if (optionIndex > this.voteOptions.length - 1 || optionIndex < 0) {
+        await this.server.rcon.warn(info.steamID, `That is not a valid option. Please try again.`);
+        return;
+      }
+      if (!this.ballotBox.has(info.steamID)) {
+        await this.server.rcon.warn(
+          info.steamID,
+          `You have voted for ${this.voteOptions[optionIndex]}.`
+        );
+      } else {
+        await this.server.rcon.warn(
+          info.steamID,
+          `You have changed your vote to ${this.voteOptions[optionIndex]}.`
+        );
+      }
+      this.ballotBox.set(info.steamID, optionIndex);
+    }
+  }
+
+  async tallyVotes() {
+    let max = 0;
+    let winner = '';
+
+    const totals = [];
+    let tie = false;
+    clearInterval(this.voteBroadcast);
+
+    for (const player of this.ballotBox) {
+      if (totals[player[1]] === undefined) {
+        totals[player[1]] = 1;
+      } else {
+        totals[player[1]]++;
+      }
+    }
+
+    for (let i = 0; i < this.voteOptions.length; i++) {
+      if (totals[i] === undefined) {
+        totals[i] = 0;
+      }
+      if (totals[i] === max) {
+        tie = true;
+      }
+      if (totals[i] > max) {
+        tie = false;
+        winner = this.voteOptions[i];
+        max = totals[i];
+      }
+    }
+
+    const totalsStr = totals
+      .map((value, index) => `${this.voteOptions[index]}: ${value} votes,`)
+      .join(' ')
+      .slice(0, -1);
+    if (tie) {
+      await this.server.rcon.broadcast(
+        `Server: There has been a tie! Total votes: ${this.ballotBox.size}.\n${totalsStr}`
+      );
+    } else {
+      await this.server.rcon.broadcast(
+        `Server: ${winner} has won the vote! Total votes: ${this.ballotBox.size}.\n${totalsStr}`
+      );
+    }
+
+    const message = {
+      content: `\`\`\`fix\nVote has ended.\nTotal votes: ${this.ballotBox.size}.\n${totalsStr}\n\`\`\``
+    };
+    await this.channel.send(message);
+    if (this.mapvote === true && winner) {
+      await this.server.rcon.execute(`AdminSetNextLayer ${winner}`);
+    }
+    this.clearVote();
+  }
+
+  // So I heard you like String Parsing?
+  async callVote(options) {
+    this.voteInProgress = true;
+
+    const broadcastStr = options.map((option, index) => `${index + 1}: ${option}`).join(' ');
+
+    const message = {
+      content: `\`\`\`fix\n${this.info.player.name} has started a vote: ${broadcastStr}\n\`\`\``
+    };
+    await this.channel.send(message);
+
+    await this.server.rcon.broadcast(
+      `Server: A vote has started! Enter a number to vote!\n${broadcastStr}`
+    );
+    this.voteBroadcast = setInterval(async () => {
+      await this.server.rcon.broadcast(
+        `Server: A vote is in progress! Enter a number to vote!\n${broadcastStr}\nTotal votes: ${this.ballotBox.size}`
+      );
+    }, 30 * 1000);
+
+    this.voteTimeout = setTimeout(this.tallyVotes, this.options.voteTime * 1000);
+  }
+
+  async getLayers() {
+    let Layers = await this.server.rcon.getListLayers();
+
+    for (const word of this.options.blacklist) {
+      if (word.toLowerCase() === 'aas') {
+        Layers = this.filterLayersByPattern(Layers, 'raas', false);
+      }
+      Layers = this.filterLayersByPattern(Layers, word.toLowerCase(), false);
+    }
+
+    for (const word of this.options.whitelist) {
+      if (word.toLowerCase() === 'aas') {
+        Layers = this.filterLayersByPattern(Layers, 'raas', false);
+      }
+      Layers = this.filterLayersByPattern(Layers, word);
+    }
+
+    // Remove Recently Played Base maps
+    // this can blow up if layerHistory Contains Null or Undefined..
+    // But the likey should happen inside of the server index.js,
+    for (const layer of this.server.layerHistory.slice(0, this.options.layerHistoryLimit - 1)) {
+      if (this.options.disallowRepeatedInvasion) {
+        if (
+          this.server.layerHistory.filter((layer) => layer.layer.classname.includes('invasion'))
+        ) {
+          Layers = this.filterLayersByPattern(Layers, 'invasion', false);
+        }
+      }
+
+      Layers = this.filterLayersByPattern(
+        Layers,
+        this.checkAndRemovePrefix(layer.layer.classname),
+        false
+      );
+    }
+    return Layers;
+  }
+
+  parseVoteParams(options) {
+    if (options === null) {
+      return;
+    }
+
+    const patterns = [];
+    for (const option of options.map((option) => option.toLowerCase())) {
+      // Parse search pattners.
+      // yeho:aas:v1 => [yeho, aas, v1]
+
+      // Shift more specific options to front of search patterns
+      // This is done so less specific options don't collide and cause a search failure
+      // aas aas yeho:aas => yeho:aas aas aas
+      if (option.includes(':')) {
+        patterns.unshift(option.split(':'));
+      } else {
+        patterns.push([option]);
+      }
+    }
+
+    return patterns;
+  }
+
+  async getLayerOptions(params) {
+    const selectedLayers = [];
+    let Layers = await this.getLayers();
+
+    // Default Case, "!mapvote" no options
+    if (!params) {
+      for (let x = 0; x < 3; x++) {
+        const selectedLayer = Layers[Math.floor(Math.random() * Layers.length)];
+
+        if (selectedLayer.includes('CAF_')) {
+          if (this.options.allowMultipleCAF === false) {
+            Layers = this.filterLayersByPattern(Layers, 'CAF_', false);
+          }
+        }
+
+        Layers = this.filterLayersByPattern(
+          Layers,
+          this.checkAndRemovePrefix(selectedLayer),
+          false
+        );
+
+        selectedLayers.push(selectedLayer);
+      }
+
+      return selectedLayers;
+    }
+
+    //! mapvote option:sub option....
+
+    for (const param of params) {
+      let candidateLayers = Layers;
+
+      // Remove exact Duplicate Layers
+      candidateLayers = candidateLayers.filter((Layer) => !selectedLayers.includes(Layer));
+
+      for (const p of param) {
+        // Remove RAAS from AAS
+        if (p === 'aas') {
+          candidateLayers = this.filterLayersByPattern(candidateLayers, 'raas', false);
+        }
+        candidateLayers = this.filterLayersByPattern(candidateLayers, p);
+      }
+
+      const selectedLayer = candidateLayers[Math.floor(Math.random() * candidateLayers.length)];
+
+      if (selectedLayer) {
+        selectedLayers.push(selectedLayer);
+
+        if (selectedLayer.includes('CAF_')) {
+          if (this.options.allowMultipleCAF === false) {
+            Layers = this.filterLayersByPattern(Layers, 'CAF_', false);
+          }
+        }
+        // we need to selectively filter the layers
+        // if our search params is a single option, remove the same base map
+        // Do not Remove Duplicates on Advanced Search
+        // We want admins to be able to specify 3 of a layer
+        // 'yeho:ass yeho:raas yeho:inv'
+        if (param.length === 1) {
+          Layers = this.filterLayersByPattern(
+            Layers,
+            this.checkAndRemovePrefix(selectedLayer),
+            false
+          );
+        }
+      }
+    }
+    if (selectedLayers.length !== params.length) {
+      // Warn And Cancel Vote?
+    }
+
+    return selectedLayers;
+  }
+
+  filterLayersByPattern(Layers, Pattern, match = true) {
+    if (match) {
+      return Layers.filter((Layer) => Layer.toLowerCase().includes(Pattern.toLowerCase()));
+    }
+    return Layers.filter((Layer) => !Layer.toLowerCase().includes(Pattern.toLowerCase()));
+  }
+
+  checkAndRemovePrefix(layer) {
+    for (const prefix of this.options.layerPrefixes) {
+      if (layer.toLowerCase().startsWith(prefix.toLowerCase())) {
+        return layer
+          .toLowerCase()
+          .replace(/_/g, '')
+          .slice(prefix.length - 1, prefix.length + 4);
+      }
+    }
+    return layer.toLowerCase().replace(/_/g, '').slice(0, 5);
+  }
+
+  clearVote() {
+    this.mapvote = false;
+    this.voteInProgress = false;
+    this.ballotBox = new Map();
+    this.voteOptions = [];
+  }
+}

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -3,17 +3,17 @@ import DiscordBasePlugin from './discord-base-plugin.js';
 export default class ttVote extends DiscordBasePlugin {
   static get description() {
     return (
-      'The <code>tt-vote</code> plugin provides complex voting functionality.\n' +
-      ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting\n ' +
-      ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply\n ' +
-      ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map.\n ' +
-      ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable\n ' +
-      ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF\n ' +
+      'The <code>tt-vote</code> plugin provides complex voting functionality. \n' +
+      ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting \n' +
+      ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply \n' +
+      ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. \n' +
+      ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable \n' +
+      ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF \n' +
       ' * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes. ' +
-      ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map\n ' +
-      ' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n ' +
-      ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n ' +
-      'Once a vote is in progress it either must end, or be canceled before starting another vote \n ' +
+      ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map \n' +
+      ' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n' +
+      ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n' +
+      'Once a vote is in progress it either must end, or be canceled before starting another vote \n' +
       'During a vote, every 30 seconds the options are Broadcast to the server \n' +
       'Automatically Sets Nextmap \n' +
       'Players vote via sending a matching number in any chat \n ' +
@@ -23,7 +23,7 @@ export default class ttVote extends DiscordBasePlugin {
       '\n\n' +
       'Admin Commands (Admin Chat Only):\n' +
       ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
-      ' * <code>!mapvote aas inv raas </code>- \n' +
+      ' * <code>!mapvote aas inv raas </code> \n' +
       ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.\n' +
       ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
       ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -1,0 +1,489 @@
+import DiscordBasePlugin from './discord-base-plugin.js';
+
+export default class ttVote extends DiscordBasePlugin {
+  static get description() {
+    return (
+      'The <code>tt-vote</code> plugin provides complex voting functionality:\n' +
+      '\n\n' +
+      ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting \n' +
+      ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply \n' +
+      ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. \n' +
+      ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable \n' +
+      ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF \n' +
+      ' * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes. ' +
+      ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map \n' +
+      ' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n' +
+      ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n' +
+      'Once a vote is in progress it either must end, or be canceled before starting another vote \n' +
+      'During a vote, every 30 seconds the options are Broadcast to the server \n' +
+      'Automatically Sets Nextmap \n' +
+      'Players vote via sending a matching number in any chat \n ' +
+      '\n\n' +
+      'Player Commands:\n' +
+      ' * <code>Number</code> - Vote for a layer using the layer number.\n' +
+      '\n\n' +
+      'Admin Commands (Admin Chat Only):\n' +
+      ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
+      ' * <code>!mapvote aas inv raas </code> \n' +
+      ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.\n' +
+      ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
+      ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +
+      ' * <code>!endvote</code> - End a vote Early, Totalling the ballots.\n'
+    );
+  }
+
+  static get defaultEnabled() {
+    return true;
+  }
+
+  static get optionsSpecification() {
+    return {
+      ...DiscordBasePlugin.optionsSpecification,
+      channelID: {
+        required: true,
+        description: 'The ID of the channel to log vote broadcasts to.',
+        default: '',
+        example: '667741905228136459'
+      },
+      voteTime: {
+        required: false,
+        description: 'The amount of time for players to vote in seconds.',
+        default: null,
+        example: 120
+      },
+      ignoreChats: {
+        required: true,
+        description: 'The chat channels to ignore.',
+        default: null,
+        example: ['ChatAll']
+      },
+      blacklist: {
+        required: true,
+        description: 'Layers, Modes, and Words to remove',
+        default: ['insurgency', 'jensens', 'destruction'],
+        example: ['caf_', 'insurgency', 'jensens', 'destruction']
+      },
+      whitelist: {
+        required: true,
+        description: 'Layers, Modes, and Words to restrict options to',
+        default: [],
+        example: ['RAAS']
+      },
+      layerHistoryLimit: {
+        required: true,
+        description:
+          'The set of previous maps to exclude layers from the next vote, stops repeated short rotations',
+        default: 0,
+        example: 2
+      },
+      allowMultipleCAF: {
+        required: false,
+        description: 'if each set of layer options should attempt to only have a single CAF layer',
+        default: true,
+        example: true
+      },
+      disallowRepeatedInvasion: {
+        required: false,
+        description: 'Attempt to limit Invasion if recently played in map History',
+        default: true,
+        example: true
+      },
+      layerPrefixes: {
+        required: true,
+        description: 'Map Prefixes from Mods or DLC, used to filter out base maps',
+        default: ['CAF_'],
+        example: ['CAF_', 'BAL_', 'GC_', 'HLP_', 'HRR_']
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+
+    this.onChatMessage = this.onChatMessage.bind(this);
+    this.onNewGame = this.onNewGame.bind(this);
+    this.tallyVotes = this.tallyVotes.bind(this);
+    this.callVote = this.callVote.bind(this);
+    this.parseVoteParams = this.parseVoteParams.bind(this);
+    this.getLayerOptions = this.getLayerOptions.bind(this);
+    this.checkAndRemovePrefix = this.checkAndRemovePrefix.bind(this);
+    this.clearVote = this.clearVote.bind(this);
+    this.mapvote = false;
+    this.voteInProgress = false;
+    this.ballotBox = new Map();
+    this.voteOptions = [];
+  }
+
+  async mount() {
+    this.server.on('CHAT_MESSAGE', this.onChatMessage);
+    this.server.on('NEW_GAME', this.onNewGame);
+    // NEW GAME is unreliable with mods.
+  }
+
+  async unmount() {
+    this.server.on('CHAT_MESSAGE', this.onChatMessage);
+    this.server.on('NEW_GAME', this.onNewGame);
+  }
+
+  async onNewGame(info) {
+    this.clearVote();
+    clearInterval(this.voteBroadcast);
+    clearInterval(this.voteTimeout);
+  }
+
+  async onChatMessage(info) {
+    this.info = info;
+
+    // EXIT IF VOTE IN PROGRESS
+    if (
+      this.voteInProgress &&
+      (info.message.toLowerCase().startsWith('!vote') ||
+        info.message.toLowerCase().startsWith('!mapvote')) &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      await this.server.rcon.warn(
+        info.steamID,
+        'Vote already in progress. Type !cancelvote or !endvote to end the vote early'
+      );
+      return;
+    }
+
+    // START A VOTE
+    if (
+      !this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!vote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      this.voteOptions = info.message.slice(6, info.message.length).match(/[A-z0-9:]+/g);
+      if (!this.voteOptions || this.voteOptions.length < 2) {
+        await this.server.rcon.warn(info.steamID, 'Please input at least two vote options.');
+        return;
+      }
+
+      this.callVote(this.voteOptions);
+    }
+
+    // Start a mapvote
+    if (
+      !this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!mapvote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      // Default case of !mapvote with no args
+      if (info.message.toLowerCase() === '!mapvote') {
+        this.mapvote = true;
+        this.voteOptions = await this.getLayerOptions();
+        await this.callVote(this.voteOptions);
+        return;
+      }
+
+      // Otherwise...
+      const params = this.parseVoteParams(
+        info.message
+          .slice(9, info.message.length)
+          .toLowerCase()
+          .match(/[a-z0-9:]+/g)
+      );
+      if (params.length < 2 || params.length > 4) {
+        await this.server.rcon.warn(info.steamID, 'Please input between 2-4 vote options.');
+        return;
+      }
+      this.voteOptions = await this.getLayerOptions(params);
+      if (params.length !== this.voteOptions.length) {
+        await this.server.rcon.warn(
+          info.steamID,
+          'Vote Cancelled, perhaps one of maps/modes you tried to select was recently played or blacklisted?'
+        );
+        return;
+      }
+      this.mapvote = true;
+      await this.callVote(this.voteOptions);
+    }
+
+    // End a vote, counting totals
+    if (
+      this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!endvote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      clearTimeout(this.voteTimeout);
+      clearInterval(this.voteBroadcast);
+      await this.tallyVotes();
+      return;
+    }
+    // Cancel a Vote, No Totals
+    if (
+      this.voteInProgress &&
+      info.message.toLowerCase().startsWith('!cancelvote') &&
+      !this.options.ignoreChats.includes(info.chat)
+    ) {
+      this.clearVote();
+      clearTimeout(this.voteTimeout);
+      clearInterval(this.voteBroadcast);
+
+      await this.server.rcon.warn(info.steamID, 'Vote Cancelled');
+      await this.server.rcon.broadcast(`Server: Vote Has Been Canceled by an Admin`);
+
+      return;
+    }
+
+    // PLAYER VOTES HERE
+    if (this.voteInProgress && info.message.match(/^[0-9]+/)) {
+      const optionIndex = parseInt(info.message) - 1;
+      if (optionIndex > this.voteOptions.length - 1 || optionIndex < 0) {
+        await this.server.rcon.warn(info.steamID, `That is not a valid option. Please try again.`);
+        return;
+      }
+      if (!this.ballotBox.has(info.steamID)) {
+        await this.server.rcon.warn(
+          info.steamID,
+          `You have voted for ${this.voteOptions[optionIndex]}.`
+        );
+      } else {
+        await this.server.rcon.warn(
+          info.steamID,
+          `You have changed your vote to ${this.voteOptions[optionIndex]}.`
+        );
+      }
+      this.ballotBox.set(info.steamID, optionIndex);
+    }
+  }
+
+  async tallyVotes() {
+    let max = 0;
+    let winner = '';
+
+    const totals = [];
+    let tie = false;
+    clearInterval(this.voteBroadcast);
+
+    for (const player of this.ballotBox) {
+      if (totals[player[1]] === undefined) {
+        totals[player[1]] = 1;
+      } else {
+        totals[player[1]]++;
+      }
+    }
+
+    for (let i = 0; i < this.voteOptions.length; i++) {
+      if (totals[i] === undefined) {
+        totals[i] = 0;
+      }
+      if (totals[i] === max) {
+        tie = true;
+      }
+      if (totals[i] > max) {
+        tie = false;
+        winner = this.voteOptions[i];
+        max = totals[i];
+      }
+    }
+
+    const totalsStr = totals
+      .map((value, index) => `${this.voteOptions[index]}: ${value} votes,`)
+      .join(' ')
+      .slice(0, -1);
+    if (tie) {
+      await this.server.rcon.broadcast(
+        `Server: There has been a tie! Total votes: ${this.ballotBox.size}.\n${totalsStr}`
+      );
+    } else {
+      await this.server.rcon.broadcast(
+        `Server: ${winner} has won the vote! Total votes: ${this.ballotBox.size}.\n${totalsStr}`
+      );
+    }
+
+    const message = {
+      content: `\`\`\`fix\nVote has ended.\nTotal votes: ${this.ballotBox.size}.\n${totalsStr}\n\`\`\``
+    };
+    await this.channel.send(message);
+    if (this.mapvote === true && winner) {
+      await this.server.rcon.execute(`AdminSetNextLayer ${winner}`);
+    }
+    this.clearVote();
+  }
+
+  // So I heard you like String Parsing?
+  async callVote(options) {
+    this.voteInProgress = true;
+
+    const broadcastStr = options.map((option, index) => `${index + 1}: ${option}`).join(' ');
+
+    const message = {
+      content: `\`\`\`fix\n${this.info.player.name} has started a vote: ${broadcastStr}\n\`\`\``
+    };
+    await this.channel.send(message);
+
+    await this.server.rcon.broadcast(
+      `Server: A vote has started! Enter a number to vote!\n${broadcastStr}`
+    );
+    this.voteBroadcast = setInterval(async () => {
+      await this.server.rcon.broadcast(
+        `Server: A vote is in progress! Enter a number to vote!\n${broadcastStr}\nTotal votes: ${this.ballotBox.size}`
+      );
+    }, 30 * 1000);
+
+    this.voteTimeout = setTimeout(this.tallyVotes, this.options.voteTime * 1000);
+  }
+
+  async getLayers() {
+    let Layers = await this.server.rcon.getListLayers();
+
+    for (const word of this.options.blacklist) {
+      if (word.toLowerCase() === 'aas') {
+        Layers = this.filterLayersByPattern(Layers, 'raas', false);
+      }
+      Layers = this.filterLayersByPattern(Layers, word.toLowerCase(), false);
+    }
+
+    for (const word of this.options.whitelist) {
+      if (word.toLowerCase() === 'aas') {
+        Layers = this.filterLayersByPattern(Layers, 'raas', false);
+      }
+      Layers = this.filterLayersByPattern(Layers, word);
+    }
+
+    // Remove Recently Played Base maps
+    // this can blow up if layerHistory Contains Null or Undefined..
+    // But the likey should happen inside of the server index.js,
+    for (const layer of this.server.layerHistory.slice(0, this.options.layerHistoryLimit - 1)) {
+      if (this.options.disallowRepeatedInvasion) {
+        if (
+          this.server.layerHistory.filter((layer) => layer.layer.classname.includes('invasion'))
+        ) {
+          Layers = this.filterLayersByPattern(Layers, 'invasion', false);
+        }
+      }
+
+      Layers = this.filterLayersByPattern(
+        Layers,
+        this.checkAndRemovePrefix(layer.layer.classname),
+        false
+      );
+    }
+    return Layers;
+  }
+
+  parseVoteParams(options) {
+    if (options === null) {
+      return;
+    }
+
+    const patterns = [];
+    for (const option of options.map((option) => option.toLowerCase())) {
+      // Parse search pattners.
+      // yeho:aas:v1 => [yeho, aas, v1]
+
+      // Shift more specific options to front of search patterns
+      // This is done so less specific options don't collide and cause a search failure
+      // aas aas yeho:aas => yeho:aas aas aas
+      if (option.includes(':')) {
+        patterns.unshift(option.split(':'));
+      } else {
+        patterns.push([option]);
+      }
+    }
+
+    return patterns;
+  }
+
+  async getLayerOptions(params) {
+    const selectedLayers = [];
+    let Layers = await this.getLayers();
+
+    // Default Case, "!mapvote" no options
+    if (!params) {
+      for (let x = 0; x < 3; x++) {
+        const selectedLayer = Layers[Math.floor(Math.random() * Layers.length)];
+
+        if (selectedLayer.includes('CAF_')) {
+          if (this.options.allowMultipleCAF === false) {
+            Layers = this.filterLayersByPattern(Layers, 'CAF_', false);
+          }
+        }
+
+        Layers = this.filterLayersByPattern(
+          Layers,
+          this.checkAndRemovePrefix(selectedLayer),
+          false
+        );
+
+        selectedLayers.push(selectedLayer);
+      }
+
+      return selectedLayers;
+    }
+
+    //! mapvote option:sub option....
+
+    for (const param of params) {
+      let candidateLayers = Layers;
+
+      // Remove exact Duplicate Layers
+      candidateLayers = candidateLayers.filter((Layer) => !selectedLayers.includes(Layer));
+
+      for (const p of param) {
+        // Remove RAAS from AAS
+        if (p === 'aas') {
+          candidateLayers = this.filterLayersByPattern(candidateLayers, 'raas', false);
+        }
+        candidateLayers = this.filterLayersByPattern(candidateLayers, p);
+      }
+
+      const selectedLayer = candidateLayers[Math.floor(Math.random() * candidateLayers.length)];
+
+      if (selectedLayer) {
+        selectedLayers.push(selectedLayer);
+
+        if (selectedLayer.includes('CAF_')) {
+          if (this.options.allowMultipleCAF === false) {
+            Layers = this.filterLayersByPattern(Layers, 'CAF_', false);
+          }
+        }
+        // we need to selectively filter the layers
+        // if our search params is a single option, remove the same base map
+        // Do not Remove Duplicates on Advanced Search
+        // We want admins to be able to specify 3 of a layer
+        // 'yeho:ass yeho:raas yeho:inv'
+        if (param.length === 1) {
+          Layers = this.filterLayersByPattern(
+            Layers,
+            this.checkAndRemovePrefix(selectedLayer),
+            false
+          );
+        }
+      }
+    }
+    if (selectedLayers.length !== params.length) {
+      // Warn And Cancel Vote?
+    }
+
+    return selectedLayers;
+  }
+
+  filterLayersByPattern(Layers, Pattern, match = true) {
+    if (match) {
+      return Layers.filter((Layer) => Layer.toLowerCase().includes(Pattern.toLowerCase()));
+    }
+    return Layers.filter((Layer) => !Layer.toLowerCase().includes(Pattern.toLowerCase()));
+  }
+
+  checkAndRemovePrefix(layer) {
+    for (const prefix of this.options.layerPrefixes) {
+      if (layer.toLowerCase().startsWith(prefix.toLowerCase())) {
+        return layer
+          .toLowerCase()
+          .replace(/_/g, '')
+          .slice(prefix.length - 1, prefix.length + 4);
+      }
+    }
+    return layer.toLowerCase().replace(/_/g, '').slice(0, 5);
+  }
+
+  clearVote() {
+    this.mapvote = false;
+    this.voteInProgress = false;
+    this.ballotBox = new Map();
+    this.voteOptions = [];
+  }
+}

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -3,7 +3,7 @@ import DiscordBasePlugin from './discord-base-plugin.js';
 export default class ttVote extends DiscordBasePlugin {
   static get description() {
     return (
-      'The <code>tt-vote</code> plugin provides complex voting functionality. \n' +
+      'The <code>tt-vote</code> plugin provides complex voting functionality: \n' +
       ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting \n' +
       ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply \n' +
       ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. \n' +

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -15,11 +15,11 @@ export default class ttVote extends DiscordBasePlugin {
       ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n ' +
       'Once a vote is in progress it either must end, or be canceled before starting another vote \n ' +
       'During a vote, every 30 seconds the options are Broadcast to the server \n' +
-      'Automatically Sets Nextmap\n ' +
-      'Players vote via sending a matching number in any chat \n' +
+      'Automatically Sets Nextmap \n' +
+      'Players vote via sending a matching number in any chat \n ' +
       '\n\n' +
       'Player Commands:\n' +
-      ' * <code><layer number></code> - Vote for a layer using the layer number.\n' +
+      ' * <code>Number</code> - Vote for a layer using the layer number.\n' +
       '\n\n' +
       'Admin Commands (Admin Chat Only):\n' +
       ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -4,30 +4,30 @@ export default class ttVote extends DiscordBasePlugin {
   static get description() {
     return (
       'The <code>tt-vote</code> plugin provides complex voting functionality.\n' +
-        ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting\n ' +
-        ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply\n ' +
-        ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map.\n ' +
-        ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable\n ' +
-        ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF\n ' +
-        ' * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes. ' +
-        ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map\n ',
-      +' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n ' +
-        ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n ' +
-        'Once a vote is in progress it either must end, or be canceled before starting another vote \n ' +
-        'During a vote, every 30 seconds the options are Broadcast to the server \n' +
-        'Automatically Sets Nextmap\n ' +
-        'Players vote via sending a matching number in any chat \n' +
-        '\n\n' +
-        'Player Commands:\n' +
-        ' * <code><layer number></code> - Vote for a layer using the layer number.\n' +
-        '\n\n' +
-        'Admin Commands (Admin Chat Only):\n' +
-        ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
-        ' * <code>!mapvote aas inv raas </code>- \n' +
-        ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.\n' +
-        ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
-        ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +
-        ' * <code>!endvote</code> - End a vote Early, Totalling the ballots.\n'
+      ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting\n ' +
+      ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply\n ' +
+      ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map.\n ' +
+      ' * <code>Double Invasion Limiting</code> - Invasion can be filtered out if recently played, stopping back to back invasion games, this is configurable\n ' +
+      ' * <code>Limit CAF_ Layers to one option per vote</code> - CAF has many more layers than any other faction, leading to a bias in random selection toward CAF\n ' +
+      ' * <code>Mod Support</code> - This plugin uses RCON to get a list of layers, so Modded layers should automatically appear in votes. ' +
+      ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map\n ' +
+      ' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n ' +
+      ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n ' +
+      'Once a vote is in progress it either must end, or be canceled before starting another vote \n ' +
+      'During a vote, every 30 seconds the options are Broadcast to the server \n' +
+      'Automatically Sets Nextmap\n ' +
+      'Players vote via sending a matching number in any chat \n' +
+      '\n\n' +
+      'Player Commands:\n' +
+      ' * <code><layer number></code> - Vote for a layer using the layer number.\n' +
+      '\n\n' +
+      'Admin Commands (Admin Chat Only):\n' +
+      ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
+      ' * <code>!mapvote aas inv raas </code>- \n' +
+      ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.\n' +
+      ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
+      ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +
+      ' * <code>!endvote</code> - End a vote Early, Totalling the ballots.\n'
     );
   }
 

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -24,8 +24,8 @@ export default class ttVote extends DiscordBasePlugin {
       '\n\n' +
       'Admin Commands (Admin Chat Only):\n' +
       ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
-      ' * <code>!mapvote aas inv raas </code> \n' +
-      ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - End the map vote and announce the winner.\n' +
+      ' * <code>!mapvote aas inv raas </code> - search via game mode\n' +
+      ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - layer:mode, can stack deeper for specifc versions\n' +
       ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
       ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +
       ' * <code>!endvote</code> - End a vote Early, Totalling the ballots.\n'

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -14,19 +14,19 @@ export default class ttVote extends DiscordBasePlugin {
       ' Simply add the Mod Prefix in your config file, this will help attempt dedpulicating modded layers by base map \n' +
       ' * <code>Layer/Mode whitelisting</code> - Simple search terms can be filter the map pool, allowing ease of selecting specific mod/Gamemode only vote options\n' +
       ' * <code>Layer/Mode Blacklisting</code> - Simple search terms can be filtered out of the map pool, useful for eliminating maps/modes from vote options\n' +
-      'Once a vote is in progress it either must end, or be canceled before starting another vote \n' +
-      'During a vote, every 30 seconds the options are Broadcast to the server \n' +
-      'Automatically Sets Nextmap \n' +
-      'Players vote via sending a matching number in any chat \n ' +
+      'Once a vote is in progress it either must end, or be canceled before starting another vote\n' +
+      'During a vote, every 30 seconds the options are Broadcast to the server\n' +
+      'Automatically Sets Nextmap\n' +
+      'Players vote via sending a matching number in any chat\n ' +
       '\n\n' +
       'Player Commands:\n' +
       ' * <code>Number</code> - Vote for a layer using the layer number.\n' +
       '\n\n' +
       'Admin Commands (Admin Chat Only):\n' +
       ' * <code>!mapvote</code> - Start a new map vote with 3 random maps.\n' +
-      ' * <code>!mapvote aas inv raas </code> - search via game mode\n' +
-      ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> - layer:mode, can stack deeper for specifc versions\n' +
-      ' * <code>!vote option1 option2 option 3</code> - Simple vote for anythin besides maps (Admin must set whatever options)\n' +
+      ' * <code>!mapvote aas inv raas </code> Example GameMode search\n' +
+      ' * <code>!mapvote yeho:raas narva:tc goro:inv</code> Example Layer Search\n' +
+      ' * <code>!vote option1 option2 option 3</code> - Simple vote for anything besides maps (Admin must set whatever options)\n' +
       ' * <code>!cancelvote</code> - Cancel the currently running vote, without totaling the ballots\n' +
       ' * <code>!endvote</code> - End a vote Early, Totalling the ballots.\n'
     );
@@ -53,9 +53,9 @@ export default class ttVote extends DiscordBasePlugin {
       },
       ignoreChats: {
         required: true,
-        description: 'The chat channels to ignore.',
-        default: null,
-        example: ['ChatAll']
+        description: 'The chat channels to ignore for reading commands',
+        default: ['ChatAll', 'ChatSquad', 'ChatTeam'],
+        example: ['ChatAll', 'ChatSquad', 'ChatTeam']
       },
       blacklist: {
         required: true,

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -346,11 +346,9 @@ export default class ttVote extends DiscordBasePlugin {
     // Remove Recently Played Base maps
     // this can blow up if layerHistory Contains Null or Undefined..
     // But the likey should happen inside of the server index.js,
-    for (const layer of this.server.layerHistory.slice(0, this.options.layerHistoryLimit - 1)) {
+    for (const layer of this.server.layerHistory.slice(0, this.options.layerHistoryLimit)) {
       if (this.options.disallowRepeatedInvasion) {
-        if (
-          this.server.layerHistory.filter((layer) => layer.layer.classname.includes('invasion'))
-        ) {
+        if (layer.layer.classname.toLowerCase().includes('invasion')) {
           Layers = this.filterLayersByPattern(Layers, 'invasion', false);
         }
       }

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -182,7 +182,7 @@ export default class ttVote extends DiscordBasePlugin {
         info.message
           .slice(9, info.message.length)
           .toLowerCase()
-          .match(/[a-z0-9:]+/g)
+          .match(/[a-z0-9:_-]+/g)
       );
       if (params.length < 2 || params.length > 4) {
         await this.server.rcon.warn(info.steamID, 'Please input between 2-4 vote options.');
@@ -347,6 +347,9 @@ export default class ttVote extends DiscordBasePlugin {
     // this can blow up if layerHistory Contains Null or Undefined..
     // But the likey should happen inside of the server index.js,
     for (const layer of this.server.layerHistory.slice(0, this.options.layerHistoryLimit)) {
+      if (layer.layer === null) {
+        continue;
+      }
       if (this.options.disallowRepeatedInvasion) {
         if (layer.layer.classname.toLowerCase().includes('invasion')) {
           Layers = this.filterLayersByPattern(Layers, 'invasion', false);

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -3,7 +3,9 @@ import DiscordBasePlugin from './discord-base-plugin.js';
 export default class ttVote extends DiscordBasePlugin {
   static get description() {
     return (
-      'The <code>tt-vote</code> plugin provides complex voting functionality: \n' +
+      'The <code>tt-vote</code> plugin provides complex voting functionality. \n' +
+      'features:\n' +
+      '\n\n' +
       ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting \n' +
       ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply \n' +
       ' * <code>Layer Deduplication by base map</code> - Layers for the next vote take into account recently played maps, and will attempt to exclude layers sharing the base map. \n' +

--- a/squad-server/plugins/ttvote.js
+++ b/squad-server/plugins/ttvote.js
@@ -3,8 +3,7 @@ import DiscordBasePlugin from './discord-base-plugin.js';
 export default class ttVote extends DiscordBasePlugin {
   static get description() {
     return (
-      'The <code>tt-vote</code> plugin provides complex voting functionality. \n' +
-      'features:\n' +
+      'The <code>tt-vote</code> plugin provides complex voting functionality:\n' +
       '\n\n' +
       ' * <code>Simple Voting</code> - Admins can specify a simple vote in addition to map voting \n' +
       ' * <code>Mapvote Command Parsing</code> - Admins can specify a mix of layers, modes, or other "search" terms when specifying a mapvote quickly and simply \n' +

--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -139,6 +139,44 @@ export default class SquadRcon extends Rcon {
     return players;
   }
 
+  async getListLayers() {
+    const response = await this.execute('ListLayers');
+
+    const Layers = [];
+
+    for (const line of response.split('\n')) {
+      // Negate Header, otherwise Assume line = Layer
+      // 'List of available layers :'
+      // 'Anvil_AAS_v1'
+
+      const match = line.match(/^(?!List of available layers :).*/);
+      if (!match) continue;
+
+      Layers.push(match[0]);
+    }
+
+    return Layers;
+  }
+
+  async getListLevels() {
+    const response = await this.execute('ListLevels');
+
+    const Levels = [];
+
+    for (const line of response.split('\n')) {
+      // Negate Header, otherwise Assume line = Level
+      // List of available levels :
+      // Anvil
+
+      const match = line.match(/^(?!List of available levels).*/);
+      if (!match) continue;
+
+      Levels.push(match[0]);
+    }
+
+    return Levels;
+  }
+
   async getSquads() {
     const responseSquad = await this.execute('ListSquads');
 

--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -151,8 +151,9 @@ export default class SquadRcon extends Rcon {
 
       const match = line.match(/^(?!List of available layers :).*/);
       if (!match) continue;
-
-      Layers.push(match[0]);
+      // mods will have layer (modpack)
+      // HRR_Chora_GRAAS_v1_CAF (HawksLayerPack)
+      Layers.push(match[0].split(' ')[0]);
     }
 
     return Layers;


### PR DESCRIPTION
Added ListLayers and ListLevels to RCON. 

Added ttVote plugin. Name can be changed, I saw someone else is working on map voting, they are free to grab ideas from this. 

Plugin does not (as of this commit) automatically run mapvotes each round OR allow players to start mapvotes. 

Those are simple changes; however there are edge cases around players repeatedly calling votes with no cooldown that need to be accounted for. As is, the plugin is fairly well tested, if a bit ugly in places. 

Some things could be turned into functions and unrolled into a more elegant tree, but it works. 