### PR TITLE
Improve regular expression used to detect new games

### DIFF
--- a/squad-server/log-parser/new-game.js
+++ b/squad-server/log-parser/new-game.js
@@ -1,6 +1,10 @@
 export default {
-  regex: /^\[([0-9.:-]+)]\[([ 0-9]*)]LogWorld: Bringing World \/([A-z]+)\/Maps\/([A-z]+)\/(?:Gameplay_Layers\/)?([A-z0-9_]+)/,
+  regex:
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogWorld: Bringing World \/([A-z]+)\/(?:Maps\/)?([A-z0-9-]+)\/(?:.+\/)?([A-z0-9-]+)(?:\.[A-z0-9-]+)/,
   onMatch: (args, logParser) => {
+    if (args[5] === 'TransitionMap') {
+      return;
+    }
     const data = {
       ...logParser.eventStore.WON,
       raw: args[0],


### PR DESCRIPTION
This regex searches for all the current information we get via the NewGame event, but with a few patterns that search deeper/different folder structures.

Appears to work on all base game content and mods that I have tested, however, mods may capture garbage information inside of mapClassname.

This will also fail if a modder puts no folders between the root of their project and their layers

/mymod/mymap

vs

/mymod/afolder/mymap

afolder would end up being the mapClassname.

https://regex101.com/r/e0Ui0K/1