### PR TITLE
Suicide Handler

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -242,6 +242,15 @@ export default class SquadServer extends EventEmitter {
       if (data.teamkill) this.emit('TEAMKILL', data);
     });
 
+    this.logParser.on('PLAYER_SUICIDE', async (data) => {
+      data.victim = await this.getPlayerByName(data.victimName);
+      data.attacker = null; // we don't want it to count +1 kill
+
+      delete data.victimName;
+
+      this.emit('PLAYER_SUICIDE', data);
+    });
+
     this.logParser.on('PLAYER_DIED', async (data) => {
       data.victim = await this.getPlayerByName(data.victimName);
 
@@ -290,11 +299,10 @@ export default class SquadServer extends EventEmitter {
     });
 
     this.logParser.on('SQUAD_CREATED', async (data) => {
-
-      data.player = await this.getPlayerBySteamID(data.playerSteamID, true)
-      delete data.playerName
-      delete data.playerSteamID
-      delete data.squadID
+      data.player = await this.getPlayerBySteamID(data.playerSteamID, true);
+      delete data.playerName;
+      delete data.playerSteamID;
+      delete data.squadID;
 
       this.emit('SQUAD_CREATED', data);
     });

--- a/squad-server/log-parser/player-suicide.js
+++ b/squad-server/log-parser/player-suicide.js
@@ -1,0 +1,17 @@
+export default {
+  regex: /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: Warning: Suicide (.+)/,
+  onMatch: (args, logParser) => {
+    const data = {
+      ...logParser.eventStore[args[3]],
+      raw: args[0],
+      time: args[1],
+      chainID: args[2],
+      victimName: args[3],
+      weapon: 'suicide' // easy to filter for DB
+    };
+
+    logParser.eventStore[args[3]] = data;
+
+    logParser.emit('PLAYER_SUICIDE', data);
+  }
+};

--- a/squad-server/plugins/db-log.js
+++ b/squad-server/plugins/db-log.js
@@ -428,6 +428,7 @@ export default class DBLog extends BasePlugin {
     this.server.on('UPDATED_A2S_INFORMATION', this.onUpdatedA2SInformation);
     this.server.on('NEW_GAME', this.onNewGame);
     this.server.on('PLAYER_WOUNDED', this.onPlayerWounded);
+    this.server.on('PLAYER_SUICIDE', this.onPlayerDied);
     this.server.on('PLAYER_DIED', this.onPlayerDied);
     this.server.on('PLAYER_REVIVED', this.onPlayerRevived);
   }
@@ -437,6 +438,7 @@ export default class DBLog extends BasePlugin {
     this.server.removeEventListener('UPDATED_A2S_INFORMATION', this.onTickRate);
     this.server.removeEventListener('NEW_GAME', this.onNewGame);
     this.server.removeEventListener('PLAYER_WOUNDED', this.onPlayerWounded);
+    this.server.removeEventListener('PLAYER_SUICIDE', this.onPlayerDied);
     this.server.removeEventListener('PLAYER_DIED', this.onPlayerDied);
     this.server.removeEventListener('PLAYER_REVIVED', this.onPlayerRevived);
   }

--- a/squad-server/plugins/socket-io-api.js
+++ b/squad-server/plugins/socket-io-api.js
@@ -16,6 +16,7 @@ const eventsToBroadcast = [
   'PLAYER_DAMAGED',
   'PLAYER_WOUNDED',
   'PLAYER_DIED',
+  'PLAYER_SUICIDE',
   'PLAYER_REVIVED',
   'TEAMKILL',
   'PLAYER_POSSESS',


### PR DESCRIPTION
@Thomas-Smyth regarding DBLog I've just used onPlayerDied. Issue might be where attacker (and woundtime, etc) will be null.
The main purpose is there, I don't see any issue of the other info being null as the purpose is catching someone using suicide event and logging it/emitting it.

I don't think I miss anything, but double check please :)