### PR TITLE
Add Leader/Kit Change events pending RCON Changes Pending https://github.com/bumbummen99/SquadJS/tree/patch-3

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -359,6 +359,26 @@ export default class SquadServer extends EventEmitter {
             oldSquadID: oldPlayerInfo[player.steamID].squadID,
             newSquadID: player.squadID
           });
+        if (
+          player.leader !== oldPlayerInfo[player.steamID].leader &&
+          oldPlayerInfo[player.steamID].leader === true
+        )
+          this.emit('PLAYER_SQUADLEADER_LOST', {
+            player: player
+          });
+        if (
+          player.leader !== oldPlayerInfo[player.steamID].leader &&
+          oldPlayerInfo[player.steamID].leader === false
+        )
+          this.emit('PLAYER_SQUADLEADER_GAINED', {
+            player: player
+          });
+        if (player.kit !== oldPlayerInfo[player.steamID].kit)
+          this.emit('PLAYER_ROLE_CHANGED', {
+            player: player,
+            oldRole: oldPlayerInfo[player.steamID].role,
+            newRole: player.role
+          });
       }
 
       this.emit('UPDATED_PLAYER_INFORMATION');

--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -290,11 +290,10 @@ export default class SquadServer extends EventEmitter {
     });
 
     this.logParser.on('SQUAD_CREATED', async (data) => {
-
-      data.player = await this.getPlayerBySteamID(data.playerSteamID, true)
-      delete data.playerName
-      delete data.playerSteamID
-      delete data.squadID
+      data.player = await this.getPlayerBySteamID(data.playerSteamID, true);
+      delete data.playerName;
+      delete data.playerSteamID;
+      delete data.squadID;
 
       this.emit('SQUAD_CREATED', data);
     });
@@ -373,7 +372,7 @@ export default class SquadServer extends EventEmitter {
           this.emit('PLAYER_SQUADLEADER_GAINED', {
             player: player
           });
-        if (player.kit !== oldPlayerInfo[player.steamID].kit)
+        if (player.role !== oldPlayerInfo[player.steamID].role)
           this.emit('PLAYER_ROLE_CHANGED', {
             player: player,
             oldRole: oldPlayerInfo[player.steamID].role,


### PR DESCRIPTION
Adds events based off new RCON information in

https://github.com/bumbummen99/SquadJS/tree/patch-3


PLAYER_SQUADLEADER_GAINED
PLAYER_SQUADLEADER_LOST
PLAYER_ROLE_CHANGED