### PR TITLE
Fix handling of layers without tanks or helicopters

### DIFF
--- a/squad-server/layers/layer.js
+++ b/squad-server/layers/layer.js
@@ -2,7 +2,7 @@ export default class Layer {
   constructor(data) {
     this.name = data.Name;
     this.classname = data.levelName;
-    this.layerid = data.rawName
+    this.layerid = data.rawName;
     this.map = {
       name: data.mapName
     };
@@ -30,10 +30,10 @@ export default class Layer {
           spawnDelay: vehicle.delay,
           respawnDelay: vehicle.respawnTime
         })),
-        numberOfTanks: data[t].vehicles.filter((v) => {
+        numberOfTanks: (data[t].vehicles || []).filter((v) => {
           return v.icon.match(/tank/);
         }).length,
-        numberOfHelicopters: data[t].vehicles.filter((v) => {
+        numberOfHelicopters: (data[t].vehicles || []).filter((v) => {
           return v.icon.match(/helo/);
         }).length
       });


### PR DESCRIPTION
2.12 Squad, some layers have no vehicles, so when reading JSON from the wiki team we reject a promise because no data[t].vehicles property, this sets to empty array before we attempt a filter.

Should stop promise rejection during startup