### PR TITLE
Update admin list on layer changes

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -190,6 +190,7 @@ export default class SquadServer extends EventEmitter {
       this.layerHistory = this.layerHistory.slice(0, this.layerHistoryMaxLength);
 
       this.currentLayer = data.layer;
+      await this.updateAdmins();
       this.emit('NEW_GAME', data);
     });
 
@@ -290,11 +291,10 @@ export default class SquadServer extends EventEmitter {
     });
 
     this.logParser.on('SQUAD_CREATED', async (data) => {
-
-      data.player = await this.getPlayerBySteamID(data.playerSteamID, true)
-      delete data.playerName
-      delete data.playerSteamID
-      delete data.squadID
+      data.player = await this.getPlayerBySteamID(data.playerSteamID, true);
+      delete data.playerName;
+      delete data.playerSteamID;
+      delete data.squadID;
 
       this.emit('SQUAD_CREATED', data);
     });
@@ -322,6 +322,10 @@ export default class SquadServer extends EventEmitter {
       if (perm in perms) ret.push(steamID);
     }
     return ret;
+  }
+
+  async updateAdmins() {
+    this.admins = await fetchAdminLists(this.options.adminLists);
   }
 
   async updatePlayerList() {


### PR DESCRIPTION
We currently only update/refresh this.admins on startup. 

This PR ties updates into new game, ensuring one update per game to recache state. 