### PR TITLE
Improve round end information, and add DiscordRoundEnded plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,29 @@ Grafana:
         </details>
 
 <details>
+          <summary>DiscordRoundEnded</summary>
+          <h2>DiscordRoundEnded</h2>
+          <p>The <code>DiscordRoundEnded</code> plugin will send the round winner to a Discord channel.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log round end events to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embed.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li></ul>
+        </details>
+
+<details>
           <summary>DiscordServerStatus</summary>
           <h2>DiscordServerStatus</h2>
           <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord.</p>

--- a/config.json
+++ b/config.json
@@ -167,6 +167,13 @@
       "color": 16761867
     },
     {
+      "plugin": "DiscordRoundEnded",
+      "enabled": true,
+      "discordClient": "discord",
+      "channelID": "",
+      "color": 16761867
+    },
+    {
       "plugin": "DiscordServerStatus",
       "enabled": true,
       "discordClient": "discord",

--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -290,6 +290,10 @@ export default class SquadServer extends EventEmitter {
       this.emit('PLAYER_UNPOSSESS', data);
     });
 
+    this.logParser.on('ROUND_ENDED', async (data) => {
+      this.emit('ROUND_ENDED', data);
+    });
+
     this.logParser.on('TICK_RATE', (data) => {
       this.emit('TICK_RATE', data);
     });

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -11,6 +11,8 @@ import PlayerPossess from './player-possess.js';
 import PlayerRevived from './player-revived.js';
 import PlayerUnPossess from './player-un-possess.js';
 import PlayerWounded from './player-wounded.js';
+import RoundEnded from './round-ended.js';
+import RoundTickets from './round-tickets.js';
 import RoundWinner from './round-winner.js';
 import ServerTickRate from './server-tick-rate.js';
 import SteamIDConnected from './steamid-connected.js';
@@ -34,6 +36,8 @@ export default class SquadLogParser extends LogParser {
       PlayerRevived,
       PlayerUnPossess,
       PlayerWounded,
+      RoundEnded,
+      RoundTickets,
       RoundWinner,
       ServerTickRate,
       SteamIDConnected,

--- a/squad-server/log-parser/round-ended.js
+++ b/squad-server/log-parser/round-ended.js
@@ -1,0 +1,20 @@
+/**
+ * Matches when Map state Changes to PostMatch (ScoreBoard)
+ *
+ * Emits winner and loser from eventstore
+ *
+ * winner and loser may be null if the match ends with a draw
+ */
+export default {
+  regex:
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogGameState: Match State Changed from InProgress to WaitingPostMatch/,
+  onMatch: (args, logParser) => {
+    const data = {
+      winner: logParser.eventStore.ROUND_WINNER ? logParser.eventStore.ROUND_WINNER : null,
+      loser: logParser.eventStore.ROUND_LOSER ? logParser.eventStore.ROUND_LOSER : null
+    };
+    logParser.emit('ROUND_ENDED', data);
+    delete logParser.eventStore.ROUND_WINNER;
+    delete logParser.eventStore.ROUND_LOSER;
+  }
+};

--- a/squad-server/log-parser/round-ended.js
+++ b/squad-server/log-parser/round-ended.js
@@ -11,7 +11,8 @@ export default {
   onMatch: (args, logParser) => {
     const data = {
       winner: logParser.eventStore.ROUND_WINNER ? logParser.eventStore.ROUND_WINNER : null,
-      loser: logParser.eventStore.ROUND_LOSER ? logParser.eventStore.ROUND_LOSER : null
+      loser: logParser.eventStore.ROUND_LOSER ? logParser.eventStore.ROUND_LOSER : null,
+      time: args[1]
     };
     logParser.emit('ROUND_ENDED', data);
     delete logParser.eventStore.ROUND_WINNER;

--- a/squad-server/log-parser/round-tickets.js
+++ b/squad-server/log-parser/round-tickets.js
@@ -1,0 +1,28 @@
+/**
+ * Matches when tickets appear in the log
+ *
+ * Will not match on Draw or Map Changes before the game has started
+ */
+export default {
+  regex:
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadGameEvents: Display: Team ([0-9]), (.*) \( ?(.*?) ?\) has (won|lost) the match with ([0-9]+) Tickets on layer (.*) \(level (.*)\)!/,
+  onMatch: (args, logParser) => {
+    const data = {
+      raw: args[0],
+      time: args[1],
+      chainID: args[2],
+      team: args[3],
+      subfaction: args[4],
+      faction: args[5],
+      action: args[6],
+      tickets: args[7],
+      layer: args[8],
+      level: args[9]
+    };
+    if (data.action === 'won') {
+      logParser.eventStore.ROUND_WINNER = data;
+    } else {
+      logParser.eventStore.ROUND_LOSER = data;
+    }
+  }
+};

--- a/squad-server/plugins/discord-roundended.js
+++ b/squad-server/plugins/discord-roundended.js
@@ -50,6 +50,7 @@ export default class DiscordRoundEnded extends DiscordBasePlugin {
           timestamp: info.time.toISOString()
         }
       });
+      return;
     }
 
     await this.sendDiscordMessage({

--- a/squad-server/plugins/discord-roundended.js
+++ b/squad-server/plugins/discord-roundended.js
@@ -29,11 +29,11 @@ export default class DiscordRoundEnded extends DiscordBasePlugin {
   constructor(server, options, connectors) {
     super(server, options, connectors);
 
-    this.onNewGame = this.onNewGame.bind(this);
+    this.onRoundEnd = this.onRoundEnd.bind(this);
   }
 
   async mount() {
-    this.server.on('ROUND_ENDED', this.onNewGame);
+    this.server.on('ROUND_ENDED', this.onRoundEnd);
   }
 
   async unmount() {

--- a/squad-server/plugins/discord-roundended.js
+++ b/squad-server/plugins/discord-roundended.js
@@ -59,12 +59,12 @@ export default class DiscordRoundEnded extends DiscordBasePlugin {
         color: this.options.color,
         fields: [
           {
-            name: 'Winner',
-            value: `${info.winner.subfaction} : ${info.winner.faction} won with ${info.winner.tickets}.`
+            name: `Team ${info.winner.team} Won`,
+            value: `${info.winner.subfaction}\n ${info.winner.faction}\n won with ${info.winner.tickets} tickets.`
           },
           {
-            name: 'Loser',
-            value: `${info.loser.subfaction} : ${info.loser.faction} lost with ${info.loser.tickets}.`
+            name: `Team ${info.loser.team} Lost`,
+            value: `${info.loser.subfaction}\n ${info.loser.faction}\n lost with ${info.loser.tickets} tickets.`
           },
           {
             name: 'Ticket Difference',

--- a/squad-server/plugins/discord-roundended.js
+++ b/squad-server/plugins/discord-roundended.js
@@ -1,0 +1,78 @@
+import DiscordBasePlugin from './discord-base-plugin.js';
+
+export default class DiscordRoundEnded extends DiscordBasePlugin {
+  static get description() {
+    return 'The <code>DiscordRoundEnded</code> plugin will send the round winner to a Discord channel.';
+  }
+
+  static get defaultEnabled() {
+    return true;
+  }
+
+  static get optionsSpecification() {
+    return {
+      ...DiscordBasePlugin.optionsSpecification,
+      channelID: {
+        required: true,
+        description: 'The ID of the channel to log round end events to.',
+        default: '',
+        example: '667741905228136459'
+      },
+      color: {
+        required: false,
+        description: 'The color of the embed.',
+        default: 16761867
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+
+    this.onNewGame = this.onNewGame.bind(this);
+  }
+
+  async mount() {
+    this.server.on('ROUND_ENDED', this.onNewGame);
+  }
+
+  async unmount() {
+    this.server.removeEventListener('ROUND_ENDED', this.onRoundEnd);
+  }
+
+  async onRoundEnd(info) {
+    if (!info.winner || !info.loser) {
+      await this.sendDiscordMessage({
+        embed: {
+          title: 'Round Ended',
+          description: 'This match Ended in a Draw',
+          color: this.options.color,
+          timestamp: info.time.toISOString()
+        }
+      });
+    }
+
+    await this.sendDiscordMessage({
+      embed: {
+        title: 'Round Ended',
+        description: `${info.winner.layer} - ${info.winner.level}`,
+        color: this.options.color,
+        fields: [
+          {
+            name: 'Winner',
+            value: `${info.winner.subfaction} : ${info.winner.faction} won with ${info.winner.tickets}.`
+          },
+          {
+            name: 'Loser',
+            value: `${info.loser.subfaction} : ${info.loser.faction} lost with ${info.loser.tickets}.`
+          },
+          {
+            name: 'Ticket Difference',
+            value: `${info.winner.tickets - info.loser.tickets}.`
+          }
+        ],
+        timestamp: info.time.toISOString()
+      }
+    });
+  }
+}


### PR DESCRIPTION
```

Adds round-tickets regex to logparser; this will fire when the server prints new log lines related to tickets and factions.

Adds round-ended regex to log parser and event; this event forwards round tickets where we have both a winner and a loser to the main server object.

discord-roundended: This plugin is similar but functionally different from round winner, due to cases where the server experiences a draw.
```

This is an initial commit, and will need additional work.

Currently known issues: 

We only see round-tickets when the map is not a draw, this is fairly often, however our current round-winner event *always* fires (though incorrectly labels all matches with a winner, even if they are a draw). 

The larger issue is the changes required in DBlog and elsewhere to smooth things over, these will result in schema changes that require DBlog to alter tables. 

Further, in the case of FTP logging, we currently assume the log and rcon state are closely coupled, this is not always the case; 

This means plugins like discord-roundwinner, that take the previous map are not guaranteed to be correct, and further issues around how we construct that data abound (layers.json missing data, see https://github.com/Team-Silver-Sphere/SquadJS/pull/222 )

The well defined path here should be stable, but edge cases around FTPlogging and such make the "draw" path much harder to handle. 

```
[2022.09.28-18.23.37:222][892]LogSquadTrace: [DedicatedServer]DetermineMatchWinner(): Local Militia Group won on Kamdesh Highlands
[2022.09.28-18.23.37:222][892]LogSquadTrace: [DedicatedServer]DetermineMatchWinner(): The game was a draw on Kamdesh Highlands
[2022.09.28-18.23.37:223][892]LogGameState: Match State Changed from InProgress to WaitingPostMatch

```

The above is a map with a draw, 

Currently NEW_GAME will report 

```

Local Militia Group won on Kamdesh Highlands
```

But this is incorrect, and the new log lines will not appear, leaving an ambiguous state. 

