### PR TITLE
Adjust log parser regular expressions to handle PLA weapons

### DIFF
--- a/squad-server/log-parser/player-damaged.js
+++ b/squad-server/log-parser/player-damaged.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: Player:(.+) ActualDamage=([0-9.]+) from (.+) caused by ([A-z_0-9]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: Player:(.+) ActualDamage=([0-9.]+) from (.+) caused by ([A-z_0-9\-]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],

--- a/squad-server/log-parser/player-died.js
+++ b/squad-server/log-parser/player-died.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Die\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) caused by ([A-z_0-9]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Die\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) caused by ([A-z_0-9\-]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       ...logParser.eventStore[args[3]],

--- a/squad-server/log-parser/player-wounded.js
+++ b/squad-server/log-parser/player-wounded.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Wound\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) caused by ([A-z_0-9]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Wound\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) caused by ([A-z_0-9\-]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       ...logParser.eventStore[args[3]],


### PR DESCRIPTION
PLA weapons have a dash, which wasn't being captured with the original regex.