### PR TITLE
Fix crash caused when Discord channel cannot be fetched by channelID 

### DIFF
--- a/squad-server/plugins/discord-base-plugin.js
+++ b/squad-server/plugins/discord-base-plugin.js
@@ -15,7 +15,12 @@ export default class DiscordBasePlugin extends BasePlugin {
   }
 
   async prepareToMount() {
-    this.channel = await this.options.discordClient.channels.fetch(this.options.channelID);
+    try {
+      this.channel = await this.options.discordClient.channels.fetch(this.options.channelID);
+    } catch (error) {
+      this.channel = null;
+      this.verbose(1, `Could not fetch channel: ${this.options.channelID}`);
+    }
   }
 
   async sendDiscordMessage(message) {

--- a/squad-server/plugins/discord-base-plugin.js
+++ b/squad-server/plugins/discord-base-plugin.js
@@ -24,6 +24,11 @@ export default class DiscordBasePlugin extends BasePlugin {
   }
 
   async sendDiscordMessage(message) {
+    if (!this.channel) {
+      this.verbose(1, `Could not send Discord Message. Channel not initialized.`)
+      return;
+    }
+
     if (typeof message === 'object' && 'embed' in message)
       message.embed.footer = message.embed.footer || { text: COPYRIGHT_MESSAGE };
 

--- a/squad-server/plugins/discord-base-plugin.js
+++ b/squad-server/plugins/discord-base-plugin.js
@@ -19,7 +19,8 @@ export default class DiscordBasePlugin extends BasePlugin {
       this.channel = await this.options.discordClient.channels.fetch(this.options.channelID);
     } catch (error) {
       this.channel = null;
-      this.verbose(1, `Could not fetch channel: ${this.options.channelID}`);
+      this.verbose(1, `Could not fetch Discord channel with channelID "${this.options.channelID}". Error: ${error.message}`);
+      this.verbose(2, `${error.stack}`);
     }
   }
 


### PR DESCRIPTION
Handle discord channel not found exception in DiscordBasePlugin.prepareToMount() and DiscordBasePlugin.sendDiscordMessage()