### PR TITLE
Add timestamps to logs

### DIFF
--- a/core/logger.js
+++ b/core/logger.js
@@ -4,6 +4,7 @@ class Logger {
   constructor() {
     this.verboseness = {};
     this.colors = {};
+    this.includeTimestamps = false;
   }
 
   verbose(module, verboseness, message, ...extras) {
@@ -11,7 +12,12 @@ class Logger {
     if (typeof colorFunc !== 'function') colorFunc = chalk.white;
 
     if ((this.verboseness[module] || 1) >= verboseness)
-      console.log(`[${colorFunc(module)}][${verboseness}] ${message}`, ...extras);
+      console.log(
+        `${this.includeTimestamps ? '[' + new Date().toISOString() + ']' : ''}[${colorFunc(
+          module
+        )}][${verboseness}] ${message}`,
+        ...extras
+      );
   }
 
   setVerboseness(module, verboseness) {
@@ -20,6 +26,10 @@ class Logger {
 
   setColor(module, color) {
     this.colors[module] = color;
+  }
+
+  setTimeStamps(option) {
+    this.includeTimestamps = option;
   }
 }
 

--- a/squad-server/factory.js
+++ b/squad-server/factory.js
@@ -17,6 +17,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default class SquadServerFactory {
   static async buildFromConfig(config) {
+    Logger.setTimeStamps(config.logger.timestamps ? config.logger.timestamps : false);
+
     const plugins = await Plugins.getPlugins();
 
     for (const plugin of Object.keys(plugins)) {


### PR DESCRIPTION
Change logger string constructor;

By default, no timetamps will be logged.

if `"timestamps" : true` exists in logger config, timestamps enabled


```
[2023-01-21T02:00:40.475Z][LogParser][1] Attempting to watch log file...
[2023-01-21T02:00:40.476Z][LogParser][1] Watching log file...
[2023-01-21T02:00:40.477Z][SquadServer][1] Updating squad list...
[2023-01-21T02:00:40.566Z][SquadServer][1] Updated squad list.
[2023-01-21T02:00:40.566Z][SquadServer][1] Updating player list...
[2023-01-21T02:00:40.666Z][SquadServer][1] Updating squad list...
```

Using ISO timestamps, could change as needed. 