### PR TITLE
Add Chat Messages to DBLog Plugin

### DIFF
--- a/squad-server/plugins/db-log.js
+++ b/squad-server/plugins/db-log.js
@@ -159,11 +159,10 @@ export default class DBLog extends BasePlugin {
           notNull: true
         },
         chat: {
-          type: DataTypes.STRING,
-          primaryKey: true
+          type: DataTypes.STRING
         },
         message: {
-          type: DataTypes.STRING
+          type: DataTypes.TEXT
         },
         steamid: {
           type: DataTypes.STRING

--- a/squad-server/plugins/db-log.js
+++ b/squad-server/plugins/db-log.js
@@ -166,6 +166,15 @@ export default class DBLog extends BasePlugin {
         },
         steamid: {
           type: DataTypes.STRING
+        },
+        squadName: {
+          type: DataTypes.STRING
+        },
+        squadID: {
+          type: DataTypes.INTEGER
+        },
+        team: {
+          type: DataTypes.INTEGER
         }
       },
       {
@@ -490,7 +499,10 @@ export default class DBLog extends BasePlugin {
       time: info.time,
       steamid: info.player.steamID,
       chat: info.chat,
-      message: info.message
+      message: info.message,
+      squadName: info.player.squad ? info.player.squad.squadName : null,
+      squadID: info.player.squadID || null,
+      team: info.player.teamID
     });
   }
 


### PR DESCRIPTION
Add chat message table to DBLog

Schema includes:

Server
match
Time
Chat(teamchat/squadchat)
message
steamid

I did not create a foreign key dependence on steamuser, as I had issues when we received a chat message but had not received and created the steamuser via PLAYER_CONNECTED.