### PR TITLE
Expose a2s playtime on server

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -457,6 +457,7 @@ export default class SquadServer extends EventEmitter {
         publicQueue: parseInt(data.raw.rules.PublicQueue_i),
         reserveQueue: parseInt(data.raw.rules.ReservedQueue_i),
 
+        playtimeSeconds: parseFloat(data.raw.rules.PLAYTIME_i),
         matchTimeout: parseFloat(data.raw.rules.MatchTimeout_f),
         gameVersion: data.raw.version
       };
@@ -471,6 +472,7 @@ export default class SquadServer extends EventEmitter {
       this.publicQueue = info.publicQueue;
       this.reserveQueue = info.reserveQueue;
 
+      this.playtimeSeconds = info.playtimeSeconds;
       this.matchTimeout = info.matchTimeout;
       this.gameVersion = info.gameVersion;
 

--- a/squad-server/plugins/readme.md
+++ b/squad-server/plugins/readme.md
@@ -16,7 +16,8 @@ Stored in the server object are a range of different properties that store infor
  * `reserveSlots` - Maximum number of reserved slots.
  * `publicQueue` - Length of the public queue.
  * `reserveQueue` - Length of the reserved queue.
- * `matchTimeout` - Time until match ends?
+ * `matchTimeout` - Timelimit for the current map in minutes (Seems to be always 120 even on Jensen Range).
+ * `playtimeSeconds`- Time spend on the current map (in seconds).
  * `gameVersion` - Game version.
  * `layerHistory` - Array history of layers used with most recent at the start. Each entry is an object with layer info in.
  * `currentLayer` - The current layer.


### PR DESCRIPTION
This exposes the a2s playtime information on the SquadJS server and allows it to be used in plugins.