### PR TITLE
Fix for Rare BufferOverflow that could cause rcon to become unresponsive core/rcon.js

### DIFF
--- a/core/rcon.js
+++ b/core/rcon.js
@@ -81,7 +81,7 @@ export default class Rcon extends EventEmitter {
     this.#write(this.type.command, id + 2);
   }
   #write(type, id, body) {
-    Logger.verbose("RCON", 2, `Writing packet with type "${type}", id "${id}" and body "${string || ""}".`); //console.warn("RCON", 2, `Writing packet with type "${type}", id "${id}" and body "${body || ""}".`);//
+    Logger.verbose("RCON", 2, `Writing packet with type "${type}", id "${id}" and body "${body || ""}".`); //console.warn("RCON", 2, `Writing packet with type "${type}", id "${id}" and body "${body || ""}".`);//
     this.client.write(this.#encode(type, id, body).toString("binary"), "binary");
   }
   #encode(type, id, body = "") {

--- a/core/rcon.js
+++ b/core/rcon.js
@@ -1,366 +1,168 @@
-import EventEmitter from 'events';
-import net from 'net';
-import util from 'util';
-
-import Logger from './logger.js';
-
-const SERVERDATA_EXECCOMMAND = 0x02;
-const SERVERDATA_RESPONSE_VALUE = 0x00;
-const SERVERDATA_AUTH = 0x03;
-const SERVERDATA_AUTH_RESPONSE = 0x02;
-const SERVERDATA_CHAT_VALUE = 0x01;
-
-const MID_PACKET_ID = 0x01;
-const END_PACKET_ID = 0x02;
-
+import EventEmitter from "events";
+import net from "net";
+import Logger from "./logger.js";
 export default class Rcon extends EventEmitter {
   constructor(options = {}) {
     super();
-
-    // store config
-    for (const option of ['host', 'port', 'password'])
-      if (!(option in options)) throw new Error(`${option} must be specified.`);
-
+    for (const option of ["host", "port", "password"]) if (!(option in options)) throw new Error(`${option} must be specified.`);
     this.host = options.host;
     this.port = options.port;
     this.password = options.password;
-    this.autoReconnectDelay = options.autoReconnectDelay || 5000;
-
-    // bind methods
-    this.connect = this.connect.bind(this); // we bind this as we call it on the auto reconnect timeout
-    this.onData = this.onData.bind(this);
-    this.onClose = this.onClose.bind(this);
-    this.onError = this.onError.bind(this);
-
-    // setup socket
-    this.client = new net.Socket();
-    this.client.on('data', this.onData);
-    this.client.on('close', this.onClose);
-    this.client.on('error', this.onError);
-
-    // constants
-    this.maximumPacketSize = 4096;
-
-    // internal variables
+    this.client;
+    this.stream = new Buffer.alloc(0);
+    this.type = { auth: 0x03, command: 0x02, response: 0x00, server: 0x01 };
+    this.soh = { size: 7, id: 0, type: this.type.response, body: "" };
     this.connected = false;
     this.autoReconnect = false;
-    this.autoReconnectTimeout = null;
-
-    this.incomingData = Buffer.from([]);
-    this.incomingResponse = [];
-
-    this.responseCallbackQueue = [];
+    this.autoReconnectDelay = options.autoReconnectDelay || 5000;
+    this.connectionRetry;
+    this.msgId = 20;
+    this.responseString = { id: 0, body: "" };
   }
-
-  onData(data) {
-    Logger.verbose('RCON', 4, `Got data: ${this.bufToHexString(data)}`);
-
-    // the logic in this method simply splits data sent via the data event into packets regardless of how they're
-    // distributed in the event calls
-    const packets = this.decodeData(data);
-
-    for (const packet of packets) {
-      Logger.verbose('RCON', 4, `Processing packet: ${this.bufToHexString(packet)}`);
-
-      const decodedPacket = this.decodePacket(packet);
-      Logger.verbose(
-        'RCON',
-        3,
-        `Processing decoded packet: ${this.decodedPacketToString(decodedPacket)}`
-      );
-
-      switch (decodedPacket.type) {
-        case SERVERDATA_RESPONSE_VALUE:
-        case SERVERDATA_AUTH_RESPONSE:
-          switch (decodedPacket.id) {
-            case MID_PACKET_ID:
-              this.incomingResponse.push(decodedPacket);
-              break;
-            case END_PACKET_ID:
-              this.responseCallbackQueue.shift()(
-                this.incomingResponse.map((packet) => packet.body).join()
-              );
-              this.incomingResponse = [];
-              break;
-            default:
-              Logger.verbose(
-                'RCON',
-                1,
-                `Unknown packet ID ${decodedPacket.id} in: ${this.decodedPacketToString(
-                  decodedPacket
-                )}`
-              );
-          }
-          break;
-
-        case SERVERDATA_CHAT_VALUE:
-          this.processChatPacket(decodedPacket);
-          break;
-
-        default:
-          Logger.verbose(
-            'RCON',
-            1,
-            `Unknown packet type ${decodedPacket.type} in: ${this.decodedPacketToString(
-              decodedPacket
-            )}`
-          );
-      }
-    }
-  }
-
-  decodeData(data) {
-    this.incomingData = Buffer.concat([this.incomingData, data]);
-
-    const packets = [];
-
-    // we check that it's greater than 4 as if it's not then the length header is not fully present which breaks the
-    // rest of the code. We just need to wait for more data.
-    while (this.incomingData.byteLength >= 4) {
-      const size = this.incomingData.readInt32LE(0);
-      const packetSize = size + 4;
-
-      // The packet following an empty packet will report to be 10 long (14 including the size header bytes), but in
-      // it should report 17 long (21 including the size header bytes). Therefore, if the packet is 10 in size
-      // and there's enough data for it to be a longer packet then we need to probe to check it's this broken packet.
-      const probeSize = 17;
-      const probePacketSize = 21;
-
-      if (size === 10 && this.incomingData.byteLength >= probeSize) {
-        // copy the section of the incoming data of interest
-        const probeBuf = this.incomingData.slice(0, probePacketSize);
-        // decode it
-        const decodedProbePacket = this.decodePacket(probeBuf);
-        // check whether body matches
-        if (decodedProbePacket.body === '\x00\x00\x00\x01\x00\x00\x00') {
-          // it does so it's the broken packet
-          // remove the broken packet from the incoming data
-          this.incomingData = this.incomingData.slice(probePacketSize);
-          Logger.verbose('RCON', 4, `Ignoring some data: ${this.bufToHexString(probeBuf)}`);
-          continue;
-        }
-      }
-
-      if (this.incomingData.byteLength < packetSize) {
-        Logger.verbose('RCON', 4, `Waiting for more data...`);
-        break;
-      }
-
-      const packet = this.incomingData.slice(0, packetSize);
-      packets.push(packet);
-
-      this.incomingData = this.incomingData.slice(packetSize);
-    }
-
-    return packets;
-  }
-
-  decodePacket(packet) {
-    return {
-      size: packet.readInt32LE(0),
-      id: packet.readInt32LE(4),
-      type: packet.readInt32LE(8),
-      body: packet.toString('utf8', 12, packet.byteLength - 2)
-    };
-  }
-
-  processChatPacket(decodedPacket) {}
-
-  onClose(hadError) {
-    this.connected = false;
-
-    Logger.verbose('RCON', 1, `Socket closed ${hadError ? 'without' : 'with'} an error.`);
-
-    if (this.autoReconnect) {
-      Logger.verbose('RCON', 1, `Sleeping ${this.autoReconnectDelay}ms before reconnecting.`);
-      setTimeout(this.connect, this.autoReconnectDelay);
-    }
-  }
-
-  onError(err) {
-    Logger.verbose('RCON', 1, `Socket had error:`, err);
-    this.emit('RCON_ERROR', err);
-  }
-
-  connect() {
+  processChatPacket(decodedPacket) {} //console.log(decodedPacket.body);
+  async connect() {
     return new Promise((resolve, reject) => {
-      Logger.verbose('RCON', 1, `Connecting to: ${this.host}:${this.port}`);
-
-      const onConnect = async () => {
-        this.client.removeListener('error', onError);
+      Logger.verbose("RCON", 1, `Connecting to: ${this.host}:${this.port}`); //console.warn("RCON", 1, `Connecting to: ${this.host}:${this.port}`);//
+      this.client = net
+        .createConnection({ port: this.port, host: this.host }, () => this.client.write(this.#encode(this.type.auth, 2147483647, this.password).toString("binary"), "binary"))
+        .on("data", (data) => this.#onData(data))
+        .on("end", () => this.#onClose())
+        .on("error", () => this.#onNetError());
+      this.autoReconnect = true;
+      this.connectionRetry = setTimeout(() => this.connect(), this.autoReconnectDelay);
+      this.on("server", (pkt) => this.processChatPacket(pkt)).on("auth", () => {
+        clearTimeout(this.connectionRetry);
         this.connected = true;
-
-        Logger.verbose('RCON', 1, `Connected to: ${this.host}:${this.port}`);
-
-        try {
-          // connected successfully, now try auth...
-          await this.write(SERVERDATA_AUTH, this.password);
-
-          // connected and authed successfully
-          this.autoReconnect = true;
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      };
-
-      const onError = (err) => {
-        this.client.removeListener('connect', onConnect);
-
-        Logger.verbose('RCON', 1, `Failed to connect to: ${this.host}:${this.port}`, err);
-
-        reject(err);
-      };
-
-      this.client.once('connect', onConnect);
-      this.client.once('error', onError);
-
-      this.client.connect(this.port, this.host);
-    });
-  }
-
-  disconnect() {
-    return new Promise((resolve, reject) => {
-      Logger.verbose('RCON', 1, `Disconnecting from: ${this.host}:${this.port}`);
-
-      const onClose = () => {
-        this.client.removeListener('error', onError);
-
-        Logger.verbose('RCON', 1, `Disconnected from: ${this.host}:${this.port}`);
-
+        Logger.verbose("RCON", 1, `Connected to: ${this.host}:${this.port}`); //console.warn("RCON", 1, `Connected to: ${this.host}:${this.port}`);//
         resolve();
-      };
-
-      const onError = (err) => {
-        this.client.removeListener('close', onClose);
-
-        Logger.verbose('RCON', 1, `Failed to disconnect from: ${this.host}:${this.port}`, err);
-
-        reject(err);
-      };
-
-      this.client.once('close', onClose);
-      this.client.once('error', onError);
-
-      // prevent any auto reconnection happening
-      this.autoReconnect = false;
-      // clear the timeout just in case the socket closed and then we DCed
-      clearTimeout(this.autoReconnectTimeout);
-
-      this.client.end();
-    });
+      });
+    }).catch((error) => Logger.verbose("RCON", 1, `Rcon.connect() ${error}`)); //console.warn("RCON", 1, `Rcon.connect() ${error}`);//
   }
-
-  execute(command) {
-    return this.write(SERVERDATA_EXECCOMMAND, command);
-  }
-
-  write(type, body) {
+  async disconnect() {
     return new Promise((resolve, reject) => {
-      if (!this.connected) {
-        reject(new Error('Not connected.'));
-        return;
+      Logger.verbose("RCON", 1, `Disconnecting from: ${this.host}:${this.port}`); //console.warn("RCON", 1, `Disconnecting from: ${this.host}:${this.port}`);//
+      clearTimeout(this.connectionRetry);
+      this.removeAllListeners();
+      this.autoReconnect = false;
+      this.client.end();
+      this.connected = false;
+      resolve();
+    }).catch((error) => Logger.verbose("RCON", 1, `Rcon.disconnect() ${error}`)); //console.warn("RCON", 1, `Rcon.disconnect() ${error}`);//
+  }
+  async execute(body) {
+    return new Promise((resolve, reject) => {
+      if (!this.connected) return reject(new Error("Rcon not connected."));
+      if (!this.client.writable) return reject(new Error("Unable to write to node:net socket."));
+      const string = String(body);
+      const length = Buffer.from(string).length;
+      if (length > 4096) Logger.verbose("RCON", 1, `Error occurred. Oversize, "${length}" > 4096.`); //console.warn("RCON", 1, `Error occurred. Oversize, "${length}" > 4096.`);//
+      else {
+        const outputData = (data) => {
+          clearTimeout(timeOut);
+          resolve(data);
+        };
+        const timedOut = () => {
+          this.removeListener(listenerId, outputData);
+          return reject(new Error(`Rcon response time out, you may have sent too many requests`));
+        };
+        if (this.msgId > 80) this.msgId = 20;
+        const listenerId = `response${this.msgId}`;
+        const timeOut = setTimeout(timedOut, 10000);
+        this.once(listenerId, outputData);
+        this.#send(string, this.msgId);
+        this.msgId++;
       }
-
-      if (!this.client.writable) {
-        reject(new Error('Unable to write to socket.'));
-        return;
-      }
-
-      Logger.verbose('RCON', 2, `Writing packet with type "${type}" and body "${body}".`);
-
-      const encodedPacket = this.encodePacket(
-        type,
-        type !== SERVERDATA_AUTH ? MID_PACKET_ID : END_PACKET_ID,
-        body
-      );
-
-      const encodedEmptyPacket = this.encodePacket(type, END_PACKET_ID, '');
-
-      if (this.maximumPacketSize < encodedPacket.length) {
-        reject(new Error('Packet too long.'));
-        return;
-      }
-
-      const onError = (err) => {
-        Logger.verbose('RCON', 1, 'Error occurred. Wiping response action queue.', err);
-        this.responseCallbackQueue = [];
-        reject(err);
-      };
-
-      // the auth packet also sends a normal response, so we add an extra empty action to ignore it
-      if (type === SERVERDATA_AUTH) {
-        this.responseCallbackQueue.push(() => {});
-        this.responseCallbackQueue.push((decodedPacket) => {
-          this.client.removeListener('error', onError);
-          if (decodedPacket.id === -1) {
-            Logger.verbose('RCON', 1, 'Authentication failed.');
-            reject(new Error('Authentication failed.'));
-          } else {
-            Logger.verbose('RCON', 1, 'Authentication succeeded.');
-            resolve();
-          }
-        });
-      } else {
-        this.responseCallbackQueue.push((response) => {
-          this.client.removeListener('error', onError);
-
-          Logger.verbose(
-            'RCON',
-            2,
-            `Returning complete response: ${response.replace(/\r\n|\r|\n/g, '\\n')}`
-          );
-
-          resolve(response);
-        });
-      }
-
-      this.client.once('error', onError);
-
-      Logger.verbose('RCON', 4, `Sending packet: ${this.bufToHexString(encodedPacket)}`);
-      this.client.write(encodedPacket);
-
-      if (type !== SERVERDATA_AUTH) {
-        Logger.verbose(
-          'RCON',
-          4,
-          `Sending empty packet: ${this.bufToHexString(encodedEmptyPacket)}`
-        );
-        this.client.write(encodedEmptyPacket);
-      }
+    }).catch((error) => {
+      Logger.verbose("RCON", 1, `Rcon.execute() ${error}`); //console.warn("RCON", 1, `Rcon.execute() ${error}`);//
     });
   }
-
-  encodePacket(type, id, body, encoding = 'utf8') {
+  #send(body, id = 99) {
+    this.#write(this.type.command, id, body);
+    this.#write(this.type.command, id + 2);
+  }
+  #write(type, id, body) {
+    Logger.verbose("RCON", 2, `Writing packet with type "${type}", id "${id}" and body "${string || ""}".`); //console.warn("RCON", 2, `Writing packet with type "${type}", id "${id}" and body "${body || ""}".`);//
+    this.client.write(this.#encode(type, id, body).toString("binary"), "binary");
+  }
+  #encode(type, id, body = "") {
     const size = Buffer.byteLength(body) + 14;
-    const buf = Buffer.alloc(size);
-
-    buf.writeInt32LE(size - 4, 0);
-    buf.writeInt32LE(id, 4);
-    buf.writeInt32LE(type, 8);
-    buf.write(body, 12, size - 2, encoding);
-    buf.writeInt16LE(0, size - 2);
-
-    return buf;
+    const buffer = new Buffer.alloc(size);
+    buffer.writeInt32LE(size - 4, 0);
+    buffer.writeInt32LE(id, 4);
+    buffer.writeInt32LE(type, 8);
+    buffer.write(body, 12, size - 2, "utf8");
+    buffer.writeInt16LE(0, size - 2);
+    return buffer;
   }
-
-  bufToHexString(buf) {
-    return buf.toString('hex').match(/../g).join(' ');
+  #onData(data) {
+    Logger.verbose("RCON", 4, `Got data: ${this.#bufToHexString(data)}`); //console.warn("RCON", 4, `Got data: ${this.#bufToHexString(data)}`);//
+    this.stream = Buffer.concat([this.stream, data], this.stream.byteLength + data.byteLength);
+    while (this.stream.byteLength >= 7) {
+      const packet = this.#decode();
+      if (!packet) break;
+      else Logger.verbose("RCON", 3, `Processing decoded packet: Size: ${packet.size}, ID: ${packet.id}, Type: ${packet.type}, Body: ${packet.body}`); //console.warn("RCON", 3, `Processing decoded packet: Size: ${packet.size}, ID: ${packet.id}, Type: ${packet.type}, Body: ${packet.body}`);//
+      if (packet.type === this.type.response) this.#onResponse(packet);
+      else if (packet.type === this.type.server) this.emit("server", packet);
+      else if (packet.type === this.type.command) this.emit("auth");
+    }
   }
-
-  decodedPacketToString(decodedPacket) {
-    return util.inspect(decodedPacket, { breakLength: Infinity });
+  #decode() {
+    if (this.stream[0] === 0 && this.stream[1] === 1 && this.stream[2] === 0 && this.stream[3] === 0 && this.stream[4] === 0 && this.stream[5] === 0 && this.stream[6] === 0) {
+      this.stream = this.stream.subarray(7);
+      return this.soh;
+    }
+    const bufSize = this.stream.readInt32LE(0);
+    if (bufSize > 8192 || bufSize < 10) return this.#badPacket();
+    else if (bufSize <= this.stream.byteLength - 4) {
+      const bufId = this.stream.readInt32LE(4);
+      const bufType = this.stream.readInt32LE(8);
+      if (this.stream[bufSize + 2] !== 0 || this.stream[bufSize + 3] !== 0 || bufId < 0 || bufType < 0 || bufType > 5) return this.#badPacket();
+      else {
+        const response = { size: bufSize, id: bufId, type: bufType, body: this.stream.toString("utf8", 12, bufSize + 2) };
+        this.stream = this.stream.subarray(bufSize + 4);
+        return response;
+      }
+    } else return null;
   }
-
+  #onResponse(packet) {
+    if (packet.body === "") {
+      this.emit(`response${this.responseString.id - 2}`, this.responseString.body);
+      this.responseString.body = "";
+    } else if (!packet.body.includes("")) {
+      this.responseString.body = this.responseString.body += packet.body;
+      this.responseString.id = packet.id;
+    } else this.#badPacket();
+  }
+  #badPacket() {
+    Logger.verbose("RCON", 1, `Bad packet, clearing: ${this.bufToHexString(this.stream)} Pending string: ${this.responseString}`); //console.warn("RCON", 1, `Bad packet, clearing: ${this.bufToHexString(this.stream)} Pending string: ${this.responseString}`);//
+    this.stream = Buffer.alloc(0);
+    this.responseString = "";
+    return null;
+  }
+  #onClose() {
+    this.connected = false;
+    Logger.verbose("RCON", 1, `Socket closed.`); //console.warn("RCON", 1, `Socket closed.`);//
+    if (this.autoReconnect) {
+      Logger.verbose("RCON", 1, `Sleeping ${this.autoReconnectDelay}ms before reconnecting.`); //console.warn("RCON", 1, `Sleeping ${this.autoReconnectDelay}ms before reconnecting.`);//
+      clearTimeout(this.connectionRetry);
+      this.connectionRetry = setTimeout(() => this.connect(), this.autoReconnectDelay);
+    }
+  }
+  #onNetError(err) {
+    this.connected = false;
+    Logger.verbose("RCON", 1, `node:net error:`, err); //console.warn("RCON", 1, `node:net error:`, err);//
+    this.emit("RCON_ERROR", err);
+  }
+  #bufToHexString(buf) {
+    return buf.toString("hex").match(/../g).join(" ");
+  }
   async warn(steamID, message) {
-    await this.execute(`AdminWarn "${steamID}" ${message}`);
+    this.execute(`AdminWarn "${steamID}" ${message}`);
   }
-
   async kick(steamID, reason) {
-    await this.execute(`AdminKick "${steamID}" ${reason}`);
+    this.execute(`AdminKick "${steamID}" ${reason}`);
   }
-
   async forceTeamChange(steamID) {
-    await this.execute(`AdminForceTeamChange "${steamID}"`);
+    this.execute(`AdminForceTeamChange "${steamID}"`);
   }
 }

--- a/core/rcon.js
+++ b/core/rcon.js
@@ -156,7 +156,7 @@ export default class Rcon extends EventEmitter {
     this.#cleanUp();
   }
   #onNetError(error) {
-    Logger.verbose("RCON", 1, `node:net error:`, err);
+    Logger.verbose("RCON", 1, `node:net error:`, error);
     this.emit("RCON_ERROR", error);
     this.#cleanUp();
   }

--- a/core/rcon.js
+++ b/core/rcon.js
@@ -18,6 +18,7 @@ export default class Rcon extends EventEmitter {
     this.connectionRetry;
     this.msgId = 20;
     this.responseString = { id: 0, body: "" };
+    this.maxIncomingPacketSize = 8192; //Set at double, Squad ver 4.3 outputs oversize when server is full, checking for 4.4
   }
   processChatPacket(decodedPacket) {}
   async connect() {
@@ -60,7 +61,7 @@ export default class Rcon extends EventEmitter {
       if (!this.client.writable) return reject(new Error("Unable to write to node:net socket."));
       const string = String(body);
       const length = Buffer.from(string).length;
-      if (length > 4096) Logger.verbose("RCON", 1, `Error occurred. Oversize, "${length}" > 4096.`);
+      if (length > this.maxIncomingPacketSize) Logger.verbose("RCON", 1, `Error occurred. Oversize, "${length}" > ${this.maxIncomingPacketSize}.`);
       else {
         const outputData = (data) => {
           clearTimeout(timeOut);

--- a/core/rcon.js
+++ b/core/rcon.js
@@ -18,7 +18,6 @@ export default class Rcon extends EventEmitter {
     this.connectionRetry;
     this.msgId = 20;
     this.responseString = { id: 0, body: "" };
-    this.execute = this.execute.bind(this);
   }
   processChatPacket(decodedPacket) {}
   async connect() {

--- a/core/rcon.js
+++ b/core/rcon.js
@@ -146,7 +146,7 @@ export default class Rcon extends EventEmitter {
     } else this.#badPacket();
   }
   #badPacket() {
-    Logger.verbose("RCON", 1, `Bad packet, clearing: ${this.bufToHexString(this.stream)} Pending string: ${this.responseString}`);
+    Logger.verbose("RCON", 1, `Bad packet, clearing: ${this.#bufToHexString(this.stream)} Pending string: ${this.responseString}`);
     this.stream = Buffer.alloc(0);
     this.responseString = "";
     return null;

--- a/core/rcon.js
+++ b/core/rcon.js
@@ -18,7 +18,6 @@ export default class Rcon extends EventEmitter {
     this.connectionRetry;
     this.msgId = 20;
     this.responseString = { id: 0, body: "" };
-    this.maxIncomingPacketSize = 8192; //Set at double, Squad ver 4.3 outputs oversize when server is full, checking for 4.4
   }
   processChatPacket(decodedPacket) {}
   async connect() {
@@ -61,7 +60,7 @@ export default class Rcon extends EventEmitter {
       if (!this.client.writable) return reject(new Error("Unable to write to node:net socket."));
       const string = String(body);
       const length = Buffer.from(string).length;
-      if (length > this.maxIncomingPacketSize) Logger.verbose("RCON", 1, `Error occurred. Oversize, "${length}" > ${this.maxIncomingPacketSize}.`);
+      if (length > 4096) Logger.verbose("RCON", 1, `Error occurred. Oversize, "${length}" > 4096.`);
       else {
         const outputData = (data) => {
           clearTimeout(timeOut);


### PR DESCRIPTION
Bug fix to decoder for rare overflow caused by packet sequence illustrated below,
(reads from random point in the buff to get size of packet that can cause non returning loop)
looking for a packet of L10 and then looking for something on the end that matches 0100000 returns false when TCP has cut packet as shown; the next data will be "fragments". This is compounded because Squad on rare occasions sends 0100000 to denote chat msg breaks and it does not follow spec.
![image](https://user-images.githubusercontent.com/111786900/232981465-f69e1acd-330f-4c4f-a763-b0fe5f12c1fa.png)
Rework of decoder to better suite OWI Squads rcon flavour. (oversize packets, 0x01, NO 0001000, instead 0100000)
(Note all decode checking I have written is overkill but I have developed it regardless, all bad packets came from the bug above TCP does not break like that at the application layer).
See my simpleRcon examples for underlying logic.
I have 'Wrapped' my rcon client methods in SquadJS-like methods (looking to confirm I've not missed anything) 
.execute(){ .once() is achieved by using the packet id as the event id, a new counter this.msgId starts at 20 and is reset at 80, tuned for timeout errors on current map call timeout goes to aprox 10 seconds.
This is my first draft, well tested in sandbox, not yet executed with SquadJS.