### PR TITLE
DiscordServerStatus heads up settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ Grafana:
 <details>
           <summary>DiscordServerStatus</summary>
           <h2>DiscordServerStatus</h2>
-          <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord. Make sure that the option "Message Content Intent" is enabled/active on the discord bot. Otherwise it won't read the discord message.</p>
+          <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord. Make sure that the option "Message Content Intent" is enabled/active on the discord bot. Otherwise the discord bot will be unable to answer back with the server status request.</p>
           <h3>Options</h3>
           <ul><li><h4>discordClient (Required)</h4>
            <h6>Description</h6>

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ Grafana:
 <details>
           <summary>DiscordServerStatus</summary>
           <h2>DiscordServerStatus</h2>
-          <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord.</p>
+          <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord. Make sure that the option "Message Content Intent" is enabled/active on the discord bot. Otherwise it won't read the discord message.</p>
           <h3>Options</h3>
           <ul><li><h4>discordClient (Required)</h4>
            <h6>Description</h6>

--- a/squad-server/plugins/discord-server-status.js
+++ b/squad-server/plugins/discord-server-status.js
@@ -7,7 +7,7 @@ import DiscordBaseMessageUpdater from './discord-base-message-updater.js';
 
 export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
   static get description() {
-    return 'The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord. Make sure that the option "Message Content Intent" is enabled/active on your discord bot via the Discord Developer Portal. Otherwise the discord bot will be unable to answer back with the server status request';
+    return 'The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord. Make sure that you enable the "Message Content Intent" option on your Discord bot via the Discord Developer Portal, otherwise, the Discord bot will be unable to reply to messages.';
   }
 
   static get defaultEnabled() {

--- a/squad-server/plugins/discord-server-status.js
+++ b/squad-server/plugins/discord-server-status.js
@@ -7,7 +7,7 @@ import DiscordBaseMessageUpdater from './discord-base-message-updater.js';
 
 export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
   static get description() {
-    return 'The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord.';
+    return 'The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord. Make sure that the option "Message Content Intent" is enabled/active on your discord bot via the Discord Developer Portal. Otherwise the discord bot will be unable to answer back with the server status request';
   }
 
   static get defaultEnabled() {

--- a/squad-server/templates/readme-template.md
+++ b/squad-server/templates/readme-template.md
@@ -32,6 +32,7 @@ SquadJS relies on being able to access the Squad server log directory in order t
 * [Node.js](https://nodejs.org/en/) (14.x) - [Download](https://nodejs.org/en/)
 * [Yarn](https://yarnpkg.com/) (Version 1.22.0+) - [Download](https://classic.yarnpkg.com/en/docs/install)
 * Some plugins may have additional requirements.
+* Make sure the option "Message Content Intent" is enabled/active on the discord bot via your Discord Developer Portal. Otherwise the discord bot will be unable to answer back with the server status request.
 
 #### Installation
 1. [Download SquadJS](https://github.com/Team-Silver-Sphere/SquadJS/releases/latest) and unzip the download.


### PR DESCRIPTION
DiscordServerStatus heads up settings

README.md and the DiscordServerStatus plugin have a extra text lenght to inform everyone that you must have "Message Content Intent" enable on your discord Bot. Otherwise it won't be able to read the request inside the discord channel.