### PR TITLE
Track playercontrollers for death logging

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -242,6 +242,8 @@ export default class SquadServer extends EventEmitter {
     this.logParser.on('PLAYER_WOUNDED', async (data) => {
       data.victim = await this.getPlayerByName(data.victimName);
       data.attacker = await this.getPlayerByName(data.attackerName);
+      if (!data.attacker)
+        data.attacker = await this.getPlayerByController(data.attackerPlayerController);
 
       if (data.victim && data.attacker)
         data.teamkill =
@@ -257,6 +259,9 @@ export default class SquadServer extends EventEmitter {
 
     this.logParser.on('PLAYER_DIED', async (data) => {
       data.victim = await this.getPlayerByName(data.victimName);
+      data.attacker = await this.getPlayerByName(data.attackerName);
+      if (!data.attacker)
+        data.attacker = await this.getPlayerByController(data.attackerPlayerController);
 
       if (data.victim && data.attacker)
         data.teamkill =
@@ -351,6 +356,9 @@ export default class SquadServer extends EventEmitter {
         players.push({
           ...oldPlayerInfo[player.steamID],
           ...player,
+          playercontroller: this.logParser.eventStore.players[player.steamID]
+            ? this.logParser.eventStore.players[player.steamID].controller
+            : null,
           squad: await this.getSquadByID(player.teamID, player.squadID)
         });
 
@@ -540,6 +548,13 @@ export default class SquadServer extends EventEmitter {
 
   async getPlayerByNameSuffix(suffix, forceUpdate) {
     return this.getPlayerByCondition((player) => player.suffix === suffix, forceUpdate, false);
+  }
+
+  async getPlayerByController(controller, forceUpdate) {
+    return this.getPlayerByCondition(
+      (player) => player.playercontroller === controller,
+      forceUpdate
+    );
   }
 
   async pingSquadJSAPI() {


### PR DESCRIPTION
Provides slightly more accurate logging of deaths/kills and downs by keeping track of player controllers.

Code has been running on Asgard Eternal squadjs fork for a long time and works without major issues/more issues than the current implementation.