### PR TITLE
Added additional properties to getListPlayers and getSquads methods

### DIFF
--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -139,9 +139,11 @@ export default class SquadRcon extends Rcon {
 
     const players = [];
 
+    if(!response || response.length < 1) return players;
+    
     for (const line of response.split('\n')) {
       const match = line.match(
-        /ID: ([0-9]+) \| SteamID: ([0-9]{17}) \| Name: (.+) \| Team ID: ([0-9]+) \| Squad ID: ([0-9]+|N\/A)/
+        /ID: ([0-9]+) \| SteamID: ([0-9]{17}) \| Name: (.+) \| Team ID: ([0-9]+) \| Squad ID: ([0-9]+|N\/A) \| Is Leader: (True|False) \| Role: ([A-Za-z0-9_]*)\b/
       );
       if (!match) continue;
 
@@ -150,7 +152,9 @@ export default class SquadRcon extends Rcon {
         steamID: match[2],
         name: match[3],
         teamID: match[4],
-        squadID: match[5] !== 'N/A' ? match[5] : null
+        squadID: match[5] !== 'N/A' ? match[5] : null,
+        isLeader: match[6] === 'True',
+        role: match[7]
       });
     }
 
@@ -164,9 +168,11 @@ export default class SquadRcon extends Rcon {
     let teamName;
     let teamID;
 
+    if(!responseSquad || responseSquad.length < 1) return squads;
+
     for (const line of responseSquad.split('\n')) {
       const match = line.match(
-        /ID: ([0-9]+) \| Name: (.+) \| Size: ([0-9]+) \| Locked: (True|False)/
+        /ID: ([0-9]+) \| Name: (.+) \| Size: ([0-9]+) \| Locked: (True|False) \| Creator Name: (.+) \| Creator Steam ID: ([0-9]{17})/
       );
       const matchSide = line.match(/Team ID: (1|2) \((.+)\)/);
       if (matchSide) {
@@ -174,11 +180,13 @@ export default class SquadRcon extends Rcon {
         teamName = matchSide[2];
       }
       if (!match) continue;
-      await squads.push({
+      squads.push({
         squadID: match[1],
         squadName: match[2],
         size: match[3],
         locked: match[4],
+        creatorName: match[5],
+        creatorSteamID: match[6],
         teamID: teamID,
         teamName: teamName
       });


### PR DESCRIPTION
Changes were suggested [here](https://discord.com/channels/266210223406972928/714529190493290527/1169632920009461771).

This introduces several updates to the `getListPlayers` and `getSquads` methods in the `rcon.js` file, improving the amount of information returned by these methods.

For the `getListPlayers` method:

- Added a check to return the `players` array immediately if the `response` is empty or not defined. This prevents potential errors when trying to process an undefined or empty response.
- Updated the regex used to parse the response, allowing it to capture additional information about whether the player is a leader and their role.
- Added `isLeader` and `role` properties to the returned player object. The `isLeader` property is a boolean indicating whether the player is a squad leader, and the `role` property represents the role of the player.

For the `getSquads` method:

- Added a check to return the `squads` array immediately if the `responseSquad` is empty or not defined. This prevents potential errors when trying to process an undefined or empty response.
- Updated the regex used to parse the response, allowing it to capture additional information about the squad creator's name and Steam ID.
- Added `creatorName` and `creatorSteamID` properties to the returned squad object. These properties represent the name and Steam ID of the squad creator.