### PR TITLE
Improve Layer finding

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -491,7 +491,10 @@ export default class SquadServer extends EventEmitter {
       this.matchTimeout = info.matchTimeout;
       this.gameVersion = info.gameVersion;
 
-      this.currentLayer = info.currentLayer === serverlayer?.layerid ? this.currentLayer : await Layers.getLayerById(info.currentLayer);
+      if (info.currentLayer !== serverlayer?.layerid) {
+        const a2slayer = await Layers.getLayerById(info.currentLayer);
+        this.currentLayer = a2slayer ? a2slayer : this.currentLayer;
+      }
 
       this.emit('UPDATED_A2S_INFORMATION', info);
     } catch (err) {


### PR DESCRIPTION
Goal: Currently the RCON overrides any layer found by the log parser. RCON fails to find the correct layer more often and provides not up to update information on the current layer. These changes prioritize Layer updating in order of accuracy and adds using the layer information from the the A2S query (which gives layer id as opposed to RCON which gives layer name).

Idea: Basic idea of the logic is that if the current layer in `this.currentLayer` gives the same information that is given from the squad server (for either A2S or RCON) then it should not update the current layer to whatever it would possibly find (either no layer or an incorrect layer).

Special Considerations: This code also takes into account a race condition with the log parser in which if we start the RCON/A2S query then compare to the current layer data, it's possible that the log parser changed the current layer data after the squad server gave the information to the query but before that query returned in squadjs. Does this by pulling the current layer data before initiating the query.

Simpler logic could not be used (eg `if (this.currentLayer == null) update layer`) in the rare case that we lose the log parser (eg the log parser is on ftp or similar).

Testing: Currently not tested and needs sanity checking (I use different logic for my squadJS at the moment, will be copying this in and testing shortly).