### PR TITLE
Bug fix for 'PLAYER_DISCONNECTED' race condition

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -219,7 +219,10 @@ export default class SquadServer extends EventEmitter {
 
     this.logParser.on('PLAYER_DISCONNECTED', async (data) => {
       data.player = await this.getPlayerBySteamID(data.steamID);
-      if (!data.player) data.player = this.oldplayers.filter((player) => player.steamID === data.steamID)[0];
+      if (!data.player){
+        const foundoldplayers = this.oldplayers.filter((player) => player.steamID === data.steamID);
+        data.player = foundoldplayers[0] ? foundoldplayers[0] : null;
+      }
 
       this.emit('PLAYER_DISCONNECTED', data);
     });

--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -29,6 +29,7 @@ export default class SquadServer extends EventEmitter {
     this.layerHistoryMaxLength = options.layerHistoryMaxLength || 20;
 
     this.players = [];
+    this.oldplayers = [];
 
     this.squads = [];
 
@@ -218,8 +219,7 @@ export default class SquadServer extends EventEmitter {
 
     this.logParser.on('PLAYER_DISCONNECTED', async (data) => {
       data.player = await this.getPlayerBySteamID(data.steamID);
-
-      delete data.steamID;
+      if (!data.player) data.player = this.oldplayers.filter((player) => player.steamID === data.steamID)[0];
 
       this.emit('PLAYER_DISCONNECTED', data);
     });
@@ -363,6 +363,7 @@ export default class SquadServer extends EventEmitter {
         });
 
       this.players = players;
+      this.oldplayers = oldPlayerInfo;
 
       for (const player of this.players) {
         if (typeof oldPlayerInfo[player.steamID] === 'undefined') continue;


### PR DESCRIPTION
Fixes the bug described in #289.

Implements this by saving the list of `oldPlayerInfo` that `updatePlayerList()` creates and then the `PLAYER_DISCONNECT` event tries to find the player by steam id in the saved `oldPlayerInfo` list if it couldn't find it in `this.players`.