### PR TITLE
Add includeChats property

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,14 +295,15 @@ Interested in creating your own plugin? [See more here](./squad-server/plugins/r
           <h3>Options</h3>
           <ul><li><h4>commands</h4>
            <h6>Description</h6>
-           <p>An array of objects containing the following properties: <ul><li><code>command</code> - The command that initiates the message.</li><li><code>type</code> - Either <code>warn</code> or <code>broadcast</code>.</li><li><code>response</code> - The message to respond with.</li><li><code>ignoreChats</code> - A list of chats to ignore the commands in. Use this to limit it to admins.</li></ul></p>
+           <p>An array of objects containing the following properties: <ul><li><code>command</code> - The command that initiates the message.</li><li><code>type</code> - Either <code>warn</code> or <code>broadcast</code>.</li><li><code>response</code> - The message to respond with.</li><li><code>ignoreChats/includeChats</code> - Either one can be used to limit to specific in-game chats, being <code>ChatAll</code>, <code>ChatTeam</code>, <code>ChatSquad</code> and <code>ChatAdmin</code></li></ul></p>
            <h6>Default</h6>
            <pre><code>[
   {
     "command": "squadjs",
     "type": "warn",
     "response": "This server is powered by SquadJS.",
-    "ignoreChats": []
+    "ignoreChats": [],
+    "includeChats": []
   }
 ]</code></pre></li></ul>
         </details>

--- a/config.json
+++ b/config.json
@@ -73,7 +73,8 @@
           "command": "squadjs",
           "type": "warn",
           "response": "This server is powered by SquadJS.",
-          "ignoreChats": []
+          "ignoreChats": [],
+          "includeChats": []
         }
       ]
     },

--- a/squad-server/plugins/chat-commands.js
+++ b/squad-server/plugins/chat-commands.js
@@ -23,13 +23,15 @@ export default class ChatCommands extends BasePlugin {
           '<li><code>type</code> - Either <code>warn</code> or <code>broadcast</code>.</li>' +
           '<li><code>response</code> - The message to respond with.</li>' +
           '<li><code>ignoreChats</code> - A list of chats to ignore the commands in. Use this to limit it to admins.</li>' +
+          '<li><code>includeChats</code> - A list of chats to include the commands in. Use this to limit it to admins.</li>' +
           '</ul>',
         default: [
           {
             command: 'squadjs',
             type: 'warn',
             response: 'This server is powered by SquadJS.',
-            ignoreChats: []
+            ignoreChats: [],
+            includeChats: []
           }
         ]
       }
@@ -39,7 +41,11 @@ export default class ChatCommands extends BasePlugin {
   async mount() {
     for (const command of this.options.commands) {
       this.server.on(`CHAT_COMMAND:${command.command.toLowerCase()}`, async (data) => {
-        if (command.ignoreChats.includes(data.chat)) return;
+        let ignoreChats = command.ignoreChats ?? [];
+        let includeChats = command.includeChats ?? [];
+
+        if (ignoreChats.includes(data.chat)) return;
+        if (includeChats.length > 0 && !includeChats.includes(data.chat)) return;
 
         if (command.type === 'broadcast') {
           await this.server.rcon.broadcast(command.response);


### PR DESCRIPTION
This adds a `includeChats` property to `ChatCommands`.

This makes limiting commands to one specific channel much easier and cleaner in the configuration.

I saw that there are more modules with the `ignoreChats` property and if the new `includeChats` property is desired, I will make efforts to implement it for those other modules too.