### PR TITLE
Include icon and spawnerSize in squad-server\layers\layer.js

### DIFF
--- a/squad-server/layers/layer.js
+++ b/squad-server/layers/layer.js
@@ -28,7 +28,9 @@ export default class Layer {
           classname: vehicle.rawType,
           count: vehicle.count,
           spawnDelay: vehicle.delay,
-          respawnDelay: vehicle.respawnTime
+          respawnDelay: vehicle.respawnTime,
+          icon: vehicle.icon,
+          spawnerSize: vehicle.spawner_Size
         })),
         numberOfTanks: (data[t].vehicles || []).filter((v) => {
           return v.icon.match(/_tank/);


### PR DESCRIPTION
Current:
```json
{
  "name": "HX60 Transport",
  "classname": "BP_Aussie_Util_Truck_C",
  "count": 1,
  "spawnDelay": 6,
  "respawnDelay": 3
}
```
Updated:
```json
{
  "name": "HX60 Transport",
  "classname": "BP_Aussie_Util_Truck_C",
  "count": 1,
  "spawnDelay": 6,
  "respawnDelay": 3,
  "icon": "map_truck_transport",
  "spawnerSize": "APC"
}
```