### PR TITLE
Feat: Add @here & Server Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,11 +447,6 @@ Grafana:
            <p>Should players know how much in-game admins there are active/online?</p>
            <h6>Default</h6>
            <pre><code>true</code></pre></li>
-<li><h4>serverName</h4>
-           <h6>Description</h6>
-           <p>The Server Name will come across in the Discord Message</p>
-           <h6>Default</h6>
-           <pre><code>Server 1</code></pre></li></ul>
         </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -422,6 +422,11 @@ Grafana:
            <pre><code>[
   "500455137626554379"
 ]</code></pre>
+<li><h4>pingHere</h4>
+           <h6>Description</h6>
+           <p>Ping @here. Great if Admin Requests are posted to a Squad Admin ONLY channel, allows pinging only Online Admins.</p>
+           <h6>Default</h6>
+           <pre><code>false</code></pre></li>
 <li><h4>pingDelay</h4>
            <h6>Description</h6>
            <p>Cooldown for pings in milliseconds.</p>
@@ -441,7 +446,12 @@ Grafana:
            <h6>Description</h6>
            <p>Should players know how much in-game admins there are active/online?</p>
            <h6>Default</h6>
-           <pre><code>true</code></pre></li></ul>
+           <pre><code>true</code></pre></li>
+<li><h4>serverName</h4>
+           <h6>Description</h6>
+           <p>The Server Name will come across in the Discord Message</p>
+           <h6>Default</h6>
+           <pre><code>Server 1</code></pre></li></ul>
         </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -446,12 +446,7 @@ Grafana:
            <h6>Description</h6>
            <p>Should players know how much in-game admins there are active/online?</p>
            <h6>Default</h6>
-           <pre><code>true</code></pre></li>
-<li><h4>serverName</h4>
-           <h6>Description</h6>
-           <p>The Server Name will come across in the Discord Message</p>
-           <h6>Default</h6>
-           <pre><code>Server 1</code></pre></li></ul>
+           <pre><code>true</code></pre></li></ul>
         </details>
 
 <details>

--- a/config.json
+++ b/config.json
@@ -110,8 +110,7 @@
       "pingDelay": 60000,
       "color": 16761867,
       "warnInGameAdmins": false,
-      "showInGameAdmins": true,
-      "serverName": "Server 1"
+      "showInGameAdmins": true
     },
     {
       "plugin": "DiscordChat",

--- a/config.json
+++ b/config.json
@@ -106,10 +106,12 @@
       "ignorePhrases": [],
       "command": "admin",
       "pingGroups": [],
+      "pingHere": false,
       "pingDelay": 60000,
       "color": 16761867,
       "warnInGameAdmins": false,
-      "showInGameAdmins": true
+      "showInGameAdmins": true,
+      "serverName": "Server 1"
     },
     {
       "plugin": "DiscordChat",

--- a/squad-server/plugins/discord-admin-request.js
+++ b/squad-server/plugins/discord-admin-request.js
@@ -44,6 +44,12 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
         default: [],
         example: ['500455137626554379']
       },
+      pingHere: {
+        required: false,
+        description:
+          'Ping @here. Great if Admin Requests are posted to a Squad Admin ONLY channel, allows pinging only Online Admins.',
+        default: false
+      },
       pingDelay: {
         required: false,
         description: 'Cooldown for pings in milliseconds.',
@@ -64,6 +70,11 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
         required: false,
         description: 'Should players know how much in-game admins there are active/online?',
         default: true
+      },
+      serverName: {
+        required: false,
+        description: 'The Server Name will come across in the Discord Message',
+        default: 'Server 1'
       }
     };
   }
@@ -141,7 +152,19 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
     };
 
     if (this.options.pingGroups.length > 0 && Date.now() - this.options.pingDelay > this.lastPing) {
-      message.content = this.options.pingGroups.map((groupID) => `<@&${groupID}>`).join(' ');
+      if (this.options.pingHere === true && this.options.pingGroups.length === 0) {
+        message.content = `@here - Admin Requested in ${this.options.serverName}`;
+      } else if (this.options.pingHere === true && this.options.pingGroups.length > 0) {
+        message.content = `@here - Admin Requested in ${
+          this.options.serverName
+        } - ${this.options.pingGroups.map((groupID) => `<@&${groupID}>`).join(' ')}`;
+      } else if (this.options.pingHere === false && this.options.pingGroups.length === 0) {
+        message.content = `Admin Requested in ${this.options.serverName}`;
+      } else if (this.options.pingHere === false && this.options.pingGroups.length > 0) {
+        message.content = `Admin Requested in ${this.options.serverName} - ${this.options.pingGroups
+          .map((groupID) => `<@&${groupID}>`)
+          .join(' ')}`;
+      }
       this.lastPing = Date.now();
     }
 

--- a/squad-server/plugins/discord-admin-request.js
+++ b/squad-server/plugins/discord-admin-request.js
@@ -70,11 +70,6 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
         required: false,
         description: 'Should players know how much in-game admins there are active/online?',
         default: true
-      },
-      serverName: {
-        required: false,
-        description: 'The Server Name will come across in the Discord Message',
-        default: 'Server 1'
       }
     };
   }
@@ -153,15 +148,15 @@ export default class DiscordAdminRequest extends DiscordBasePlugin {
 
     if (this.options.pingGroups.length > 0 && Date.now() - this.options.pingDelay > this.lastPing) {
       if (this.options.pingHere === true && this.options.pingGroups.length === 0) {
-        message.content = `@here - Admin Requested in ${this.options.serverName}`;
+        message.content = `@here - Admin Requested in ${this.server.serverName}`;
       } else if (this.options.pingHere === true && this.options.pingGroups.length > 0) {
         message.content = `@here - Admin Requested in ${
-          this.options.serverName
+          this.server.serverName
         } - ${this.options.pingGroups.map((groupID) => `<@&${groupID}>`).join(' ')}`;
       } else if (this.options.pingHere === false && this.options.pingGroups.length === 0) {
-        message.content = `Admin Requested in ${this.options.serverName}`;
+        message.content = `Admin Requested in ${this.server.serverName}`;
       } else if (this.options.pingHere === false && this.options.pingGroups.length > 0) {
-        message.content = `Admin Requested in ${this.options.serverName} - ${this.options.pingGroups
+        message.content = `Admin Requested in ${this.server.serverName} - ${this.options.pingGroups
           .map((groupID) => `<@&${groupID}>`)
           .join(' ')}`;
       }


### PR DESCRIPTION
Adds the ability to turn on @here for Admin Requests in Discord. This allows for pinging of all ONLINE Squad Admins if the Admin Request is going to a Squad Admin only Channel.

Added the ServerName option so you can tell what server the request is coming from for communities with multi servers without having to create multi channels for each server's admin request notifs.