### PR TITLE
Feat: Support for GC's Player Controllers

### DIFF
--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -4,7 +4,9 @@ import AdminBroadcast from './admin-broadcast.js';
 import DeployableDamaged from './deployable-damaged.js';
 import NewGame from './new-game.js';
 import PlayerConnected from './player-connected.js';
+import PlayerConnectedGC from './player-connected-gc.js';
 import PlayerControllerConnected from './playercontroller-connected.js';
+import PlayerControllerConnectedGC from './playercontroller-connected-gc.js';
 import PlayerDisconnected from './player-disconnected.js';
 import PlayerDamaged from './player-damaged.js';
 import PlayerDied from './player-died.js';
@@ -36,7 +38,9 @@ export default class SquadLogParser extends LogParser {
       DeployableDamaged,
       NewGame,
       PlayerConnected,
+      PlayerConnectedGC,
       PlayerControllerConnected,
+      PlayerControllerConnectedGC,
       PlayerDisconnected,
       PlayerDamaged,
       PlayerDied,

--- a/squad-server/log-parser/player-connected-gc.js
+++ b/squad-server/log-parser/player-connected-gc.js
@@ -1,0 +1,26 @@
+export default {
+    regex:
+      /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_GC_PlayerController_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs: EOS: ([0-9a-f]{32}) steam: (\d+)\)/,
+    onMatch: (args, logParser) => {
+      const data = {
+        raw: args[0],
+        time: args[1],
+        chainID: +args[2],
+        playercontroller: args[3],
+        ip: args[4],
+        eosID: args[5],
+        steamID: args[6]
+      };
+  
+      const joinRequestData = logParser.eventStore.joinRequests[+args[2]];
+      data.connection = joinRequestData.connection;
+      data.playerSuffix = joinRequestData.suffix;
+  
+      if (!logParser.eventStore.players[data.steamID])
+        logParser.eventStore.players[data.steamID] = {};
+      logParser.eventStore.players[data.steamID].controller = data.playercontroller;
+  
+      logParser.emit('PLAYER_CONNECTED', data);
+    }
+  };
+  

--- a/squad-server/log-parser/playercontroller-connected-gc.js
+++ b/squad-server/log-parser/playercontroller-connected-gc.js
@@ -1,0 +1,15 @@
+export default {
+  regex:
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_GC_PlayerController_C .+(BP_GC_PlayerController_C_[0-9]+)/,
+  onMatch: (args, logParser) => {
+    const data = {
+      raw: args[0],
+      time: args[1],
+      chainID: +args[2],
+      controller: args[3]
+    };
+
+    logParser.eventStore.joinRequests[data.chainID].controller = data.controller;
+    logParser.emit('PLAYER_CONTROLLER_CONNECTED', data);
+  }
+};


### PR DESCRIPTION
Support for GC's Player Controllers.

I added them in the log-parser as new files instead of messing with and possibly breaking old files.

This may need to be done for any other mods that mess with the BP name for the Player Controller.

Let me know if there's a better way to implement this. But this is working for me on our Server.