### PR TITLE
Robust ID parser.

### DIFF
--- a/core/id-parser.js
+++ b/core/id-parser.js
@@ -1,0 +1,41 @@
+const ID_MATCHER = /\s*(?<name>[^:]+): (?<id>[^\s]+)/g;
+
+// PARSING AND ITERATION
+
+// main function intended for parsing `Online IDs:` body. Returns an
+// iterator that yields `{platform: id}` pairs.
+export const iterate = (idsStr) => {
+  return new IdsIterator(idsStr.matchAll(ID_MATCHER));
+};
+
+class IdsIterator {
+  constructor(matchIterator) {
+    this.inner = matchIterator;
+  }
+
+  [Symbol.iterator]() {
+    return this;
+  }
+
+  next() {
+    const match = this.inner.next();
+    if (match.done) return { value: undefined, done: true };
+    return { value: { key: match.value[1], value: match.value[2] }, done: false };
+  }
+
+  forEach(callbackFn) {
+    for (const { key, value } of this) callbackFn(key, value);
+  }
+}
+
+// FORMATTING
+
+// `steam => SteamID`
+export const capitalID = (str) => {
+  return str.charAt(0).toUpperCase() + str.slice(1) + 'ID';
+};
+
+// `EOS => eosID`
+export const lowerID = (str) => {
+  return str.toLowerCase() + 'ID';
+};

--- a/core/package.json
+++ b/core/package.json
@@ -5,6 +5,7 @@
   "exports": {
     "./log-parser": "./log-parser/index.js",
     "./constants": "./constants.js",
+    "./id-parser": "./id-parser.js",
     "./logger": "./logger.js",
     "./rcon": "./rcon.js"
   },

--- a/squad-server/log-parser/player-connected.js
+++ b/squad-server/log-parser/player-connected.js
@@ -1,16 +1,20 @@
+import { iterate, lowerID } from 'core/id-parser';
+
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs: EOS: ([0-9a-f]{32}) steam: (\d+)\)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],
       time: args[1],
       chainID: +args[2],
       playercontroller: args[3],
-      ip: args[4],
-      eosID: args[5],
-      steamID: args[6]
+      ip: args[4]
     };
+
+    iterate(args[5]).forEach((platform, id) => {
+      data[lowerID(platform)] = id;
+    });
 
     const joinRequestData = logParser.eventStore.joinRequests[+args[2]];
     data.connection = joinRequestData.connection;

--- a/squad-server/log-parser/player-damaged.js
+++ b/squad-server/log-parser/player-damaged.js
@@ -1,6 +1,8 @@
+import { iterate, capitalID } from 'core/id-parser';
+
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: Player:(.+) ActualDamage=([0-9.]+) from (.+) \(Online IDs: EOS: ([0-9a-f]{32}) steam: (\d{17}) \| Player Controller ID: ([^ ]+)\)caused by ([A-z_0-9-]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: Player:(.+) ActualDamage=([0-9.]+) from (.+) \(Online IDs:([^|]+)\| Player Controller ID: ([^ ]+)\)caused by ([A-z_0-9-]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],
@@ -9,11 +11,12 @@ export default {
       victimName: args[3],
       damage: parseFloat(args[4]),
       attackerName: args[5],
-      attackerEOSID: args[6],
-      attackerSteamID: args[7],
-      attackerController: args[8],
-      weapon: args[9]
+      attackerController: args[7],
+      weapon: args[8]
     };
+    iterate(args[6]).forEach((platform, id) => {
+      data['attacker' + capitalID(platform)] = id;
+    });
 
     logParser.eventStore.session[args[3]] = data;
 

--- a/squad-server/log-parser/player-died.js
+++ b/squad-server/log-parser/player-died.js
@@ -1,6 +1,8 @@
+import { iterate, capitalID } from 'core/id-parser';
+
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Die\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) \(Online IDs: EOS: ([\w\d]{32}) steam: (\d{17}) \| Contoller ID: ([\w\d]+)\) caused by ([A-z_0-9-]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Die\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) \(Online IDs:([^)|]+)\| Contoller ID: ([\w\d]+)\) caused by ([A-z_0-9-]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       ...logParser.eventStore.session[args[3]],
@@ -11,12 +13,13 @@ export default {
       victimName: args[3],
       damage: parseFloat(args[4]),
       attackerPlayerController: args[5],
-      attackerEOSID: args[6],
-      attackerSteamID: args[7],
-      weapon: args[9]
+      weapon: args[8]
     };
 
     logParser.eventStore.session[args[3]] = data;
+    iterate(args[6]).forEach((platform, id) => {
+      data['attacker' + capitalID(platform)] = id;
+    });
 
     logParser.emit('PLAYER_DIED', data);
   }

--- a/squad-server/log-parser/player-possess.js
+++ b/squad-server/log-parser/player-possess.js
@@ -1,19 +1,22 @@
+import { iterate, capitalID } from 'core/id-parser';
+
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQPlayerController::)?OnPossess\(\): PC=(.+) \(Online IDs: EOS: ([\w\d]{32}) steam: (\d{17})\) Pawn=([A-z0-9_]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQPlayerController::)?OnPossess\(\): PC=(.+) \(Online IDs:([^)]+)\) Pawn=([A-z0-9_]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],
       time: args[1],
       chainID: args[2],
       playerSuffix: args[3],
-      playerEOSID: args[4],
-      playerSteamID: args[5],
-      possessClassname: args[6],
-      pawn: args[5]
+      possessClassname: args[5]
     };
 
     logParser.eventStore.session[args[3]] = args[2];
+    iterate(args[4]).forEach((platform, id) => {
+      data['player' + capitalID(platform)] = id;
+    });
+    data.pawn = data.playerSteamID; // deprecated? never used in code
 
     logParser.emit('PLAYER_POSSESS', data);
   }

--- a/squad-server/log-parser/player-revived.js
+++ b/squad-server/log-parser/player-revived.js
@@ -1,7 +1,9 @@
+import { iterate, capitalID } from 'core/id-parser';
+
 export default {
   // the names are currently the wrong way around in these logs
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: (.+) \(Online IDs: EOS: ([0-9a-f]{32}) steam: (\d{17})\) has revived (.+) \(Online IDs: EOS: ([0-9a-f]{32}) steam: (\d{17})\)\./,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: (.+) \(Online IDs:([^)]+)\) has revived (.+) \(Online IDs:([^)]+)\)\./,
   onMatch: (args, logParser) => {
     const data = {
       ...logParser.eventStore.session[args[3]],
@@ -9,12 +11,14 @@ export default {
       time: args[1],
       chainID: args[2],
       reviverName: args[3],
-      reviverEOSID: args[4],
-      reviverSteamID: args[5],
-      victimName: args[6],
-      victimEOSID: args[7],
-      victimSteamID: args[8]
+      victimName: args[5]
     };
+    iterate(args[4]).forEach((platform, id) => {
+      data['reviver' + capitalID(platform)] = id;
+    });
+    iterate(args[6]).forEach((platform, id) => {
+      data['victim' + capitalID(platform)] = id;
+    });
 
     logParser.emit('PLAYER_REVIVED', data);
   }

--- a/squad-server/log-parser/player-un-possess.js
+++ b/squad-server/log-parser/player-un-possess.js
@@ -1,19 +1,22 @@
+import { iterate, capitalID } from 'core/id-parser';
+
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQPlayerController::)?OnUnPossess\(\): PC=(.+) \(Online IDs: EOS: ([\w\d]{32}) steam: (\d{17})\)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQPlayerController::)?OnUnPossess\(\): PC=(.+) \(Online IDs:([^)]+)\)/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],
       time: args[1],
       chainID: args[2],
-      playerSuffix: args[3],
-      playerEOSID: args[4],
-      playerSteamID: args[5],
-      switchPossess:
-        args[4] in logParser.eventStore.session && logParser.eventStore.session[args[4]] === args[2]
+      playerSuffix: args[3]
     };
-
-    delete logParser.eventStore.session[args[3]];
+    iterate(args[4]).forEach((platform, id) => {
+      data['player' + capitalID(platform)] = id;
+    });
+    const eosID = data.playerEOSID;
+    data.switchPossess =
+      eosID in logParser.eventStore.session && logParser.eventStore.session[eosID] === data.chainID;
+    delete logParser.eventStore.session[data.playerSuffix];
 
     logParser.emit('PLAYER_UNPOSSESS', data);
   }

--- a/squad-server/log-parser/player-wounded.js
+++ b/squad-server/log-parser/player-wounded.js
@@ -1,6 +1,8 @@
+import { iterate, capitalID } from 'core/id-parser';
+
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Wound\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) \(Online IDs: EOS: ([\w\d]{32}) steam: (\d{17}) \| Controller ID: ([\w\d]+)\) caused by ([A-z_0-9-]+)_C/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQSoldier::)?Wound\(\): Player:(.+) KillingDamage=(?:-)*([0-9.]+) from ([A-z_0-9]+) \(Online IDs:([^)|]+)\| Controller ID: ([\w\d]+)\) caused by ([A-z_0-9-]+)_C/,
   onMatch: (args, logParser) => {
     const data = {
       ...logParser.eventStore.session[args[3]],
@@ -10,12 +12,13 @@ export default {
       victimName: args[3],
       damage: parseFloat(args[4]),
       attackerPlayerController: args[5],
-      attackerEOSID: args[6],
-      attackerSteamID: args[7],
-      weapon: args[9]
+      weapon: args[8]
     };
 
     logParser.eventStore.session[args[3]] = data;
+    iterate(args[6]).forEach((platform, id) => {
+      data['attacker' + capitalID(platform)] = id;
+    });
 
     logParser.emit('PLAYER_WOUNDED', data);
   }

--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -1,54 +1,60 @@
 import Logger from 'core/logger';
 import Rcon from 'core/rcon';
+import { iterate, capitalID, lowerID } from 'core/id-parser';
 
 export default class SquadRcon extends Rcon {
   processChatPacket(decodedPacket) {
     const matchChat = decodedPacket.body.match(
-      /\[(ChatAll|ChatTeam|ChatSquad|ChatAdmin)] \[Online IDs:EOS: ([0-9a-f]{32}) steam: (\d{17})\] (.+?) : (.*)/
+      /\[(ChatAll|ChatTeam|ChatSquad|ChatAdmin)] \[Online IDs:([^\]]+)\] (.+?) : (.*)/
     );
     if (matchChat) {
       Logger.verbose('SquadRcon', 2, `Matched chat message: ${decodedPacket.body}`);
 
-      this.emit('CHAT_MESSAGE', {
+      const result = {
         raw: decodedPacket.body,
         chat: matchChat[1],
-        eosID: matchChat[2],
-        steamID: matchChat[3],
-        name: matchChat[4],
-        message: matchChat[5],
+        name: matchChat[3],
+        message: matchChat[4],
         time: new Date()
+      };
+      iterate(matchChat[2]).forEach((platform, id) => {
+        result[lowerID(platform)] = id;
       });
-
+      this.emit('CHAT_MESSAGE', result);
       return;
     }
 
     const matchPossessedAdminCam = decodedPacket.body.match(
-      /\[Online Ids:EOS: ([0-9a-f]{32}) steam: (\d{17})\] (.+) has possessed admin camera\./
+      /\[Online Ids:([^\]]+)\] (.+) has possessed admin camera\./
     );
     if (matchPossessedAdminCam) {
       Logger.verbose('SquadRcon', 2, `Matched admin camera possessed: ${decodedPacket.body}`);
-      this.emit('POSSESSED_ADMIN_CAMERA', {
+      const result = {
         raw: decodedPacket.body,
-        steamID: matchPossessedAdminCam[2],
-        name: matchPossessedAdminCam[3],
+        name: matchPossessedAdminCam[2],
         time: new Date()
+      };
+      iterate(matchPossessedAdminCam[1]).forEach((platform, id) => {
+        result[lowerID(platform)] = id;
       });
-
+      this.emit('POSSESSED_ADMIN_CAMERA', result);
       return;
     }
 
     const matchUnpossessedAdminCam = decodedPacket.body.match(
-      /\[Online IDs:EOS: ([0-9a-f]{32}) steam: (\d{17})\] (.+) has unpossessed admin camera\./
+      /\[Online IDs:([^\]]+)\] (.+) has unpossessed admin camera\./
     );
     if (matchUnpossessedAdminCam) {
-      Logger.verbose('SquadRcon', 2, `Matched admin camera possessed: ${decodedPacket.body}`);
-      this.emit('UNPOSSESSED_ADMIN_CAMERA', {
+      Logger.verbose('SquadRcon', 2, `Matched admin camera unpossessed: ${decodedPacket.body}`);
+      const result = {
         raw: decodedPacket.body,
-        steamID: matchUnpossessedAdminCam[2],
-        name: matchUnpossessedAdminCam[3],
+        name: matchUnpossessedAdminCam[2],
         time: new Date()
+      };
+      iterate(matchUnpossessedAdminCam[1]).forEach((platform, id) => {
+        result[lowerID(platform)] = id;
       });
-
+      this.emit('UNPOSSESSED_ADMIN_CAMERA', result);
       return;
     }
 
@@ -69,50 +75,57 @@ export default class SquadRcon extends Rcon {
     }
 
     const matchKick = decodedPacket.body.match(
-      /Kicked player ([0-9]+)\. \[Online IDs= EOS: ([0-9a-f]{32}) steam: (\d{17})] (.*)/
+      /Kicked player ([0-9]+)\. \[Online IDs=([^\]]+)\] (.*)/
     );
     if (matchKick) {
       Logger.verbose('SquadRcon', 2, `Matched kick message: ${decodedPacket.body}`);
 
-      this.emit('PLAYER_KICKED', {
+      const result = {
         raw: decodedPacket.body,
         playerID: matchKick[1],
-        steamID: matchKick[3],
-        name: matchKick[4],
+        name: matchKick[3],
         time: new Date()
+      };
+      iterate(matchKick[2]).forEach((platform, id) => {
+        result[lowerID(platform)] = id;
       });
-
+      this.emit('PLAYER_KICKED', result);
       return;
     }
 
     const matchSqCreated = decodedPacket.body.match(
-      /(?<playerName>.+) \(Online IDs: EOS: (?<playerEOSID>[\da-f]{32})(?: steam: (?<playerSteamID>\d{17}))?\) has created Squad (?<squadID>\d+) \(Squad Name: (?<squadName>.+)\) on (?<teamName>.+)/
+      /(?<playerName>.+) \(Online IDs:([^)]+)\) has created Squad (?<squadID>\d+) \(Squad Name: (?<squadName>.+)\) on (?<teamName>.+)/
     );
     if (matchSqCreated) {
       Logger.verbose('SquadRcon', 2, `Matched Squad Created: ${decodedPacket.body}`);
-
-      this.emit('SQUAD_CREATED', {
+      const result = {
         time: new Date(),
         ...matchSqCreated.groups
+      };
+      iterate(matchSqCreated[2]).forEach((platform, id) => {
+        result['player' + capitalID(platform)] = id;
       });
-
+      this.emit('SQUAD_CREATED', result);
       return;
     }
 
     const matchBan = decodedPacket.body.match(
-      /Banned player ([0-9]+)\. \[steamid=(.*?)\] (.*) for interval (.*)/
+      /Banned player ([0-9]+)\. \[Online IDs=([^\]]+)\] (.*) for interval (.*)/
     );
     if (matchBan) {
       Logger.verbose('SquadRcon', 2, `Matched ban message: ${decodedPacket.body}`);
 
-      this.emit('PLAYER_BANNED', {
+      const result = {
         raw: decodedPacket.body,
         playerID: matchBan[1],
-        steamID: matchBan[2],
         name: matchBan[3],
         interval: matchBan[4],
         time: new Date()
+      };
+      iterate(matchBan[2]).forEach((platform, id) => {
+        result[lowerID(platform)] = id;
       });
+      this.emit('PLAYER_BANNED', result);
     }
   }
 
@@ -140,7 +153,7 @@ export default class SquadRcon extends Rcon {
 
     for (const line of response.split('\n')) {
       const match = line.match(
-        /^ID: (?<playerID>\d+) \| Online IDs: EOS: (?<eosID>[a-f\d]{32}) (?:steam: (?<steamID>\d{17}) )?\| Name: (?<name>.+) \| Team ID: (?<teamID>\d|N\/A) \| Squad ID: (?<squadID>\d+|N\/A) \| Is Leader: (?<isLeader>True|False) \| Role: (?<role>.+)$/
+        /^ID: (?<playerID>\d+) \| Online IDs:([^|]+)\| Name: (?<name>.+) \| Team ID: (?<teamID>\d|N\/A) \| Squad ID: (?<squadID>\d+|N\/A) \| Is Leader: (?<isLeader>True|False) \| Role: (?<role>.+)$/
       );
       if (!match) continue;
 
@@ -149,10 +162,11 @@ export default class SquadRcon extends Rcon {
       data.isLeader = data.isLeader === 'True';
       data.teamID = data.teamID !== 'N/A' ? +data.teamID : null;
       data.squadID = data.squadID !== 'N/A' ? +data.squadID : null;
-
+      iterate(match[2]).forEach((platform, id) => {
+        data[lowerID(platform)] = id;
+      });
       players.push(data);
     }
-
     return players;
   }
 
@@ -167,7 +181,7 @@ export default class SquadRcon extends Rcon {
 
     for (const line of responseSquad.split('\n')) {
       const match = line.match(
-        /ID: (?<squadID>\d+) \| Name: (?<squadName>.+) \| Size: (?<size>\d+) \| Locked: (?<locked>True|False) \| Creator Name: (?<creatorName>.+) \| Creator Online IDs: EOS: (?<creatorEOSID>[a-f\d]{32})(?: steam: (?<creatorSteamID>\d{17}))?/
+        /ID: (?<squadID>\d+) \| Name: (?<squadName>.+) \| Size: (?<size>\d+) \| Locked: (?<locked>True|False) \| Creator Name: (?<creatorName>.+) \| Creator Online IDs:([^|]+)/
       );
       const matchSide = line.match(/Team ID: (\d) \((.+)\)/);
       if (matchSide) {
@@ -176,13 +190,16 @@ export default class SquadRcon extends Rcon {
       }
       if (!match) continue;
       match.groups.squadID = +match.groups.squadID;
-      squads.push({
+      const squad = {
         ...match.groups,
         teamID: teamID,
         teamName: teamName
+      };
+      iterate(match[6]).forEach((platform, id) => {
+        squad['creator' + capitalID(platform)] = id;
       });
+      squads.push(squad);
     }
-
     return squads;
   }
 


### PR DESCRIPTION
This patch resolves an issue with inconsistent ID reports from RCON and game logs. An example to illustrate the issue:

```
----- Active Players -----
ID: 1 | Online IDs: EOS: 00023b618e9c4e6e8e85122d664bdbd9 steam: 76561198923824046 | Name: [DTX] AlreadyGod | Team ID: 2 | Squad ID: 1 | Is Leader: True | Role: PLA_Medic_01
ID: 0 | Online IDs: EOS: 0002eda25e7543f18f327956dac87509 | Name:  Ulibos | Team ID: 2 | Squad ID: 2 | Is Leader: True | Role: PLA_Medic_01
----- Recently Disconnected Players [Max of 15] -----
```

Note that my profile is missing a steam ID. This is not a synthetic example, this actually happened to me and happens sometimes to others. This leads to a bunch of parsers failing to match the line and simply discarding it making the player non-existent for squadjs.

**What it does:**
Parsers read all IDs in bulk and defer matching of individual IDs to a separate function. This should also protect against potential future introduction of new platforms and IDs.

**What it doesn't:**
This PR does not fix the fact of absence of a steam ID of a player. If some functionality still relies on that, it will fail. If there is no check for an undefined steam ID somewhere, it might lead to failures. I'm hoping to address this in my next PR.