### PR TITLE
update: getNextMap to work with v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SquadJS",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "repository": "https://github.com/Team-Silver-Sphere/SquadJS.git",
   "author": "Thomas Smyth <https://github.com/Thomas-Smyth>",
   "license": "BSL-1.0",

--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -126,8 +126,8 @@ export default class SquadRcon extends Rcon {
     const response = await this.execute('ShowNextMap');
     const match = response.match(/^Next level is (.*), layer is (.*)/);
     return {
-      level: match[1] !== '' ? match[1] : null,
-      layer: match[2] !== 'To be voted' ? match[2] : null
+      level: match ? (match[1] !== '' ? match[1] : null) : null,
+      layer: match ? (match[2] !== 'To be voted' ? match[2] : null) : null
     };
   }
 


### PR DESCRIPTION
```
[SquadServer][1] Failed to update layer information. TypeError: Cannot read properties of null (reading '1')
at SquadRcon.getNextMap (file:///home/container/squad-server/rcon.js:129:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async SquadServer.updateLayerInformation (file:///home/container/squad-server/index.js:452:23)
```
V8 Updates some RCON Commands it seems

```js
async getNextMap() {
    const response = await this.execute('ShowNextMap');
    const match = response.match(/^Next level is (.*), layer is (.*)/);
    return {
      level: match[1] !== '' ? match[1] : null,
      layer: match[2] !== 'To be voted' ? match[2] : null
    };
  }
```
the new response from ShowNextMap is `Next map is not defined`
Therefore match ends up being `null` which broke the return values.

Updated to this seems to work for me so far:
```js
  async getNextMap() {
    const response = await this.execute('ShowNextMap');
    const match = response.match(/^Next level is (.*), layer is (.*)/);
    return {
      level: match ? (match[1] !== '' ? match[1] : null) : null,
      layer: match ? (match[2] !== 'To be voted' ? match[2] : null) : null
    };
  }
```