### PR TITLE
Improve layer information extraction

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -500,8 +500,8 @@ export default class SquadServer extends EventEmitter {
       const nextMap = await this.rcon.getNextMap();
       const nextMapToBeVoted = nextMap.layer === 'To be voted';
 
-      const currentLayer = await Layers.getLayerByName(currentMap.layer);
-      const nextLayer = nextMapToBeVoted ? null : await Layers.getLayerByName(nextMap.layer);
+      const currentLayer = await Layers.getLayerById(currentMap.layer);
+      const nextLayer = nextMapToBeVoted ? null : await Layers.getLayerById(nextMap.layer);
 
       if (this.layerHistory.length === 0) {
         this.layerHistory.unshift({ layer: currentLayer, time: Date.now() });

--- a/squad-server/layers/layers.js
+++ b/squad-server/layers/layers.js
@@ -45,8 +45,8 @@ class Layers {
     return null;
   }
 
-  getLayerByName(name) {
-    return this.getLayerByCondition((layer) => layer.name === name);
+  getLayerById(layerId) {
+    return this.getLayerByCondition((layer) => layer.layerid === layerId);
   }
 
   getLayerByClassname(classname) {

--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -131,13 +131,13 @@ export default class SquadRcon extends Rcon {
 
   async getCurrentMap() {
     const response = await this.execute('ShowCurrentMap');
-    const match = response.match(/^Current level is (.*), layer is (.*)/);
+    const match = response.match(/^Current level is ([^,]*), layer is ([^,]*)/);
     return { level: match[1], layer: match[2] };
   }
 
   async getNextMap() {
     const response = await this.execute('ShowNextMap');
-    const match = response.match(/^Next level is (.*), layer is (.*)/);
+    const match = response.match(/^Next level is ([^,]*), layer is ([^,]*)/);
     return {
       level: match ? (match[1] !== '' ? match[1] : null) : null,
       layer: match ? (match[2] !== 'To be voted' ? match[2] : null) : null


### PR DESCRIPTION
# Description
- `SquadServer` regularly invokes `updateLayerInformation` to update the current and next layer variables, namely `this.currentLayer` and `this.nextLayer`.
- This is fetched from `Layers` class, `getLayerByName` method, which filters the pulled layers `this.layers` by the `name` field.
- The layers are fetched from `https://raw.githubusercontent.com/Squad-Wiki/squad-wiki-pipeline-map-data/master/completed_output/_Current%20Version/finished.json`
  - I'm actually a bit concerned that this "current version" is outdated with respect to the latest Squad version 8.0.
- However, the layer name for filtering is fetched from `SquadRcon` class, `getCurrentMap` method which uses the RCON command `ShowCurrentMap`. This command returns an answer like `Current level is Jensen's Range, layer is JensensRange_USA-RGF, factions USA RGF`. The problem here is 2-fold:
  - The regex used to extract the level and the layer names is broken: `^Current level is (.*), layer is (.*)` Because the 2nd regex group actually matches a string like `JensensRange_USA-RGF, factions USA RGF`
  - Even if we correctly extract the "layer name", it actually corresponds to the `layerid` field in the pulled layers

## What this PR does
Solves those 2 problems by:
- Updating the regexes to extract the level and the layer ids from the RCON commands `ShowCurrentMap` and `ShowNextMap` as: `^Current level is ([^,]*), layer is ([^,]*)`
- Changing the matching logic to use the `layerid` field instead of `name`