### PR TITLE
Remove duplicate "victim" friend from DiscordKillFeed plugin

### DIFF
--- a/squad-server/plugins/discord-killfeed.js
+++ b/squad-server/plugins/discord-killfeed.js
@@ -82,11 +82,6 @@ export default class DiscordKillFeed extends DiscordBasePlugin {
           ? `[${info.victim.steamID}](https://steamcommunity.com/profiles/${info.victim.steamID})`
           : 'Unknown',
         inline: true
-      },
-      {
-        name: "Victim's Name",
-        value: info.victim.name,
-        inline: true
       }
     ];
 

--- a/squad-server/plugins/discord-killfeed.js
+++ b/squad-server/plugins/discord-killfeed.js
@@ -82,6 +82,11 @@ export default class DiscordKillFeed extends DiscordBasePlugin {
           ? `[${info.victim.steamID}](https://steamcommunity.com/profiles/${info.victim.steamID})`
           : 'Unknown',
         inline: true
+      },
+      {
+        name: "Victim's EosID",
+        value: info.victim ? info.victim.eosID : 'Unknown',
+        inline: true
       }
     ];
 


### PR DESCRIPTION
Fixes an oopsie I did in EOS migration, duplicating the field in the plugin. I've removed the on that wasn't performing safety checks and was ocasionally crashing people's squadjs.