### PR TITLE
Add option to load admin lists via FTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The following section of the configuration contains information about your Squad
       {
         "type": "remote",
         "source": "http://yourWebsite.com/Server1/Admins.cfg",
+      },
+      {
+        "type": "ftp",
+        "source": "ftp://<user>:<password>@<host>:<port>/<url-path>",
       }
     ]
   },
@@ -207,15 +211,26 @@ The following is a list of plugins built into SquadJS, you can click their title
 Interested in creating your own plugin? [See more here](./squad-server/plugins/readme.md)
 
 <details>
-          <summary>TeamRandomizer</summary>
-          <h2>TeamRandomizer</h2>
-          <p>The <code>TeamRandomizer</code> can be used to randomize teams. It's great for destroying clan stacks or for social events. It can be run by typing, by default, <code>!randomize</code> into in-game admin chat</p>
+          <summary>DiscordAdminCamLogs</summary>
+          <h2>DiscordAdminCamLogs</h2>
+          <p>The <code>DiscordAdminCamLogs</code> plugin will log in game admin camera usage to a Discord channel.</p>
           <h3>Options</h3>
-          <ul><li><h4>command</h4>
+          <ul><li><h4>discordClient (Required)</h4>
            <h6>Description</h6>
-           <p>The command used to randomize the teams.</p>
+           <p>Discord connector name.</p>
            <h6>Default</h6>
-           <pre><code>randomize</code></pre></li></ul>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log admin camera usage to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embed.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li></ul>
         </details>
 
 <details>
@@ -231,136 +246,6 @@ Interested in creating your own plugin? [See more here](./squad-server/plugins/r
 <li><h4>channelID (Required)</h4>
            <h6>Description</h6>
            <p>The ID of the channel to log admin broadcasts to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>color</h4>
-           <h6>Description</h6>
-           <p>The color of the embed.</p>
-           <h6>Default</h6>
-           <pre><code>16761867</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordFOBHABExplosionDamage</summary>
-          <h2>DiscordFOBHABExplosionDamage</h2>
-          <p>The <code>DiscordFOBHABExplosionDamage</code> plugin logs damage done to FOBs and HABs by explosions to help identify engineers blowing up friendly FOBs and HABs.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log FOB/HAB explosion damage to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>color</h4>
-           <h6>Description</h6>
-           <p>The color of the embeds.</p>
-           <h6>Default</h6>
-           <pre><code>16761867</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordRoundWinner</summary>
-          <h2>DiscordRoundWinner</h2>
-          <p>The <code>DiscordRoundWinner</code> plugin will send the round winner to a Discord channel.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log admin broadcasts to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>color</h4>
-           <h6>Description</h6>
-           <p>The color of the embed.</p>
-           <h6>Default</h6>
-           <pre><code>16761867</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordChat</summary>
-          <h2>DiscordChat</h2>
-          <p>The <code>DiscordChat</code> plugin will log in-game chat to a Discord channel.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log admin broadcasts to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>chatColors</h4>
-           <h6>Description</h6>
-           <p>The color of the embed for each chat.</p>
-           <h6>Default</h6>
-           <pre><code>{}</code></pre></li><h6>Example</h6>
-           <pre><code>{
-  "ChatAll": 16761867
-}</code></pre>
-<li><h4>color</h4>
-           <h6>Description</h6>
-           <p>The color of the embed.</p>
-           <h6>Default</h6>
-           <pre><code>16761867</code></pre></li>
-<li><h4>ignoreChats</h4>
-           <h6>Description</h6>
-           <p>A list of chat names to ignore.</p>
-           <h6>Default</h6>
-           <pre><code>[
-  "ChatSquad"
-]</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordRoundEnded</summary>
-          <h2>DiscordRoundEnded</h2>
-          <p>The <code>DiscordRoundEnded</code> plugin will send the round winner to a Discord channel.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log round end events to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>color</h4>
-           <h6>Description</h6>
-           <p>The color of the embed.</p>
-           <h6>Default</h6>
-           <pre><code>16761867</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordAdminCamLogs</summary>
-          <h2>DiscordAdminCamLogs</h2>
-          <p>The <code>DiscordAdminCamLogs</code> plugin will log in game admin camera usage to a Discord channel.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log admin camera usage to.</p>
            <h6>Default</h6>
            <pre><code></code></pre></li><h6>Example</h6>
            <pre><code>667741905228136459</code></pre>
@@ -404,6 +289,255 @@ Interested in creating your own plugin? [See more here](./squad-server/plugins/r
            <p>Prepend admin names when making announcements.</p>
            <h6>Default</h6>
            <pre><code>false</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DiscordRoundWinner</summary>
+          <h2>DiscordRoundWinner</h2>
+          <p>The <code>DiscordRoundWinner</code> plugin will send the round winner to a Discord channel.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log admin broadcasts to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embed.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DiscordKillFeed</summary>
+          <h2>DiscordKillFeed</h2>
+          <p>The <code>DiscordKillFeed</code> plugin logs all wounds and related information to a Discord channel for admins to review.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log teamkills to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embeds.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li>
+<li><h4>disableCBL</h4>
+           <h6>Description</h6>
+           <p>Disable Community Ban List information.</p>
+           <h6>Default</h6>
+           <pre><code>false</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DiscordPlaceholder</summary>
+          <h2>DiscordPlaceholder</h2>
+          <p>The <code>DiscordPlaceholder</code> plugin allows you to make your bot create placeholder messages that can be used when configuring other plugins.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>command</h4>
+           <h6>Description</h6>
+           <p>Command to create Discord placeholder.</p>
+           <h6>Default</h6>
+           <pre><code>!placeholder</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The bot will only answer with a placeholder on this channel</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DBLog</summary>
+          <h2>DBLog</h2>
+          <p>The <code>mysql-log</code> plugin will log various server statistics and events to a database. This is great for server performance monitoring and/or player stat tracking.
+
+Grafana:
+<ul><li> <a href="https://grafana.com/">Grafana</a> is a cool way of viewing server statistics stored in the database.</li>
+<li>Install Grafana.</li>
+<li>Add your database as a datasource named <code>SquadJS</code>.</li>
+<li>Import the <a href="https://github.com/Team-Silver-Sphere/SquadJS/blob/master/squad-server/templates/SquadJS-Dashboard-v2.json">SquadJS Dashboard</a> to get a preconfigured MySQL only Grafana dashboard.</li>
+<li>Install any missing Grafana plugins.</li></ul></p>
+          <h3>Options</h3>
+          <ul><li><h4>database (Required)</h4>
+           <h6>Description</h6>
+           <p>The Sequelize connector to log server information to.</p>
+           <h6>Default</h6>
+           <pre><code>mysql</code></pre></li>
+<li><h4>overrideServerID</h4>
+           <h6>Description</h6>
+           <p>A overridden server ID.</p>
+           <h6>Default</h6>
+           <pre><code>null</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>CBLInfo</summary>
+          <h2>CBLInfo</h2>
+          <p>The <code>CBLInfo</code> plugin alerts admins when a harmful player is detected joining their server based on data from the <a href="https://communitybanlist.com/">Community Ban List</a>.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to alert admins through.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>threshold</h4>
+           <h6>Description</h6>
+           <p>Admins will be alerted when a player has this or more reputation points. For more information on reputation points, see the <a href="https://communitybanlist.com/faq">Community Ban List's FAQ</a></p>
+           <h6>Default</h6>
+           <pre><code>6</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DiscordRoundEnded</summary>
+          <h2>DiscordRoundEnded</h2>
+          <p>The <code>DiscordRoundEnded</code> plugin will send the round winner to a Discord channel.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log round end events to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embed.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>ChatCommands</summary>
+          <h2>ChatCommands</h2>
+          <p>The <code>ChatCommands</code> plugin can be configured to make chat commands that broadcast or warn the caller with present messages.</p>
+          <h3>Options</h3>
+          <ul><li><h4>commands</h4>
+           <h6>Description</h6>
+           <p>An array of objects containing the following properties: <ul><li><code>command</code> - The command that initiates the message.</li><li><code>type</code> - Either <code>warn</code> or <code>broadcast</code>.</li><li><code>response</code> - The message to respond with.</li><li><code>ignoreChats</code> - A list of chats to ignore the commands in. Use this to limit it to admins.</li></ul></p>
+           <h6>Default</h6>
+           <pre><code>[
+  {
+    "command": "squadjs",
+    "type": "warn",
+    "response": "This server is powered by SquadJS.",
+    "ignoreChats": []
+  }
+]</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DiscordServerStatus</summary>
+          <h2>DiscordServerStatus</h2>
+          <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>messageStore (Required)</h4>
+           <h6>Description</h6>
+           <p>Sequelize connector name.</p>
+           <h6>Default</h6>
+           <pre><code>sqlite</code></pre></li>
+<li><h4>command</h4>
+           <h6>Description</h6>
+           <p>Command name to get message.</p>
+           <h6>Default</h6>
+           <pre><code>!status</code></pre></li>
+<li><h4>disableSubscriptions</h4>
+           <h6>Description</h6>
+           <p>Whether to allow messages to be subscribed to automatic updates.</p>
+           <h6>Default</h6>
+           <pre><code>false</code></pre></li>
+<li><h4>updateInterval</h4>
+           <h6>Description</h6>
+           <p>How frequently to update the time in Discord.</p>
+           <h6>Default</h6>
+           <pre><code>60000</code></pre></li>
+<li><h4>setBotStatus</h4>
+           <h6>Description</h6>
+           <p>Whether to update the bot's status with server information.</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>TeamRandomizer</summary>
+          <h2>TeamRandomizer</h2>
+          <p>The <code>TeamRandomizer</code> can be used to randomize teams. It's great for destroying clan stacks or for social events. It can be run by typing, by default, <code>!randomize</code> into in-game admin chat</p>
+          <h3>Options</h3>
+          <ul><li><h4>command</h4>
+           <h6>Description</h6>
+           <p>The command used to randomize the teams.</p>
+           <h6>Default</h6>
+           <pre><code>randomize</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>DiscordChat</summary>
+          <h2>DiscordChat</h2>
+          <p>The <code>DiscordChat</code> plugin will log in-game chat to a Discord channel.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log admin broadcasts to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>chatColors</h4>
+           <h6>Description</h6>
+           <p>The color of the embed for each chat.</p>
+           <h6>Default</h6>
+           <pre><code>{}</code></pre></li><h6>Example</h6>
+           <pre><code>{
+  "ChatAll": 16761867
+}</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embed.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li>
+<li><h4>ignoreChats</h4>
+           <h6>Description</h6>
+           <p>A list of chat names to ignore.</p>
+           <h6>Default</h6>
+           <pre><code>[
+  "ChatSquad"
+]</code></pre></li></ul>
         </details>
 
 <details>
@@ -454,6 +588,157 @@ Interested in creating your own plugin? [See more here](./squad-server/plugins/r
         </details>
 
 <details>
+          <summary>DiscordDebug</summary>
+          <h2>DiscordDebug</h2>
+          <p>The <code>DiscordDebug</code> plugin can be used to help debug SquadJS by dumping SquadJS events to a Discord channel.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log events to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>events (Required)</h4>
+           <h6>Description</h6>
+           <p>A list of events to dump.</p>
+           <h6>Default</h6>
+           <pre><code>[]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "PLAYER_DIED"
+]</code></pre></ul>
+        </details>
+
+<details>
+          <summary>DiscordSubsystemRestarter</summary>
+          <h2>DiscordSubsystemRestarter</h2>
+          <p>The <code>DiscordSubSystemRestarter</code> plugin allows you to manually restart SquadJS subsystems in case an issues arises with them.<ul><li><code>!squadjs restartsubsystem rcon</code></li><li><code>!squadjs restartsubsystem logparser</code></li></ul></p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>role (Required)</h4>
+           <h6>Description</h6>
+           <p>ID of role required to run the sub system restart commands.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre></ul>
+        </details>
+
+<details>
+          <summary>DiscordSquadCreated</summary>
+          <h2>DiscordSquadCreated</h2>
+          <p>The <code>SquadCreated</code> plugin will log Squad Creation events to a Discord channel.</p>
+          <h3>Options</h3>
+          <ul><li><h4>discordClient (Required)</h4>
+           <h6>Description</h6>
+           <p>Discord connector name.</p>
+           <h6>Default</h6>
+           <pre><code>discord</code></pre></li>
+<li><h4>channelID (Required)</h4>
+           <h6>Description</h6>
+           <p>The ID of the channel to log Squad Creation events to.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>667741905228136459</code></pre>
+<li><h4>color</h4>
+           <h6>Description</h6>
+           <p>The color of the embed.</p>
+           <h6>Default</h6>
+           <pre><code>16761867</code></pre></li>
+<li><h4>useEmbed</h4>
+           <h6>Description</h6>
+           <p>Send message as Embed</p>
+           <h6>Default</h6>
+           <pre><code>true</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>FogOfWar</summary>
+          <h2>FogOfWar</h2>
+          <p>The <code>FogOfWar</code> plugin can be used to automate setting fog of war mode.</p>
+          <h3>Options</h3>
+          <ul><li><h4>mode</h4>
+           <h6>Description</h6>
+           <p>Fog of war mode to set.</p>
+           <h6>Default</h6>
+           <pre><code>1</code></pre></li>
+<li><h4>delay</h4>
+           <h6>Description</h6>
+           <p>Delay before setting fog of war mode.</p>
+           <h6>Default</h6>
+           <pre><code>10000</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>IntervalledBroadcasts</summary>
+          <h2>IntervalledBroadcasts</h2>
+          <p>The <code>IntervalledBroadcasts</code> plugin allows you to set broadcasts, which will be broadcasted at preset intervals</p>
+          <h3>Options</h3>
+          <ul><li><h4>broadcasts</h4>
+           <h6>Description</h6>
+           <p>Messages to broadcast.</p>
+           <h6>Default</h6>
+           <pre><code>[]</code></pre></li><h6>Example</h6>
+           <pre><code>[
+  "This server is powered by SquadJS."
+]</code></pre>
+<li><h4>interval</h4>
+           <h6>Description</h6>
+           <p>Frequency of the broadcasts in milliseconds.</p>
+           <h6>Default</h6>
+           <pre><code>300000</code></pre></li></ul>
+        </details>
+
+<details>
+          <summary>SocketIOAPI</summary>
+          <h2>SocketIOAPI</h2>
+          <p>The <code>SocketIOAPI</code> plugin allows remote access to a SquadJS instance via Socket.IO<br />As a client example you can use this to connect to the socket.io server;<pre><code>
+      const socket = io.connect('ws://IP:PORT', {
+        auth: {
+          token: "MySecretPassword"
+        }
+      })
+    </code></pre>If you need more documentation about socket.io please go ahead and read the following;<br />General Socket.io documentation: <a href="https://socket.io/docs/v3" target="_blank">Socket.io Docs</a><br />Authentication and securing your websocket: <a href="https://socket.io/docs/v3/middlewares/#Sending-credentials" target="_blank">Sending-credentials</a><br />How to use, install and configure a socketIO-client: <a href="https://github.com/11TStudio/SocketIO-Examples-for-SquadJS" target="_blank">Usage Guide with Examples</a></p>
+          <h3>Options</h3>
+          <ul><li><h4>websocketPort (Required)</h4>
+           <h6>Description</h6>
+           <p>The port for the websocket.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>3000</code></pre>
+<li><h4>securityToken (Required)</h4>
+           <h6>Description</h6>
+           <p>Your secret token/password for connecting.</p>
+           <h6>Default</h6>
+           <pre><code></code></pre></li><h6>Example</h6>
+           <pre><code>MySecretPassword</code></pre></ul>
+        </details>
+
+<details>
+          <summary>AutoTKWarn</summary>
+          <h2>AutoTKWarn</h2>
+          <p>The <code>AutoTkWarn</code> plugin will automatically warn players with a message when they teamkill.</p>
+          <h3>Options</h3>
+          <ul><li><h4>attackerMessage</h4>
+           <h6>Description</h6>
+           <p>The message to warn attacking players with.</p>
+           <h6>Default</h6>
+           <pre><code>Please apologise for ALL TKs in ALL chat!</code></pre></li>
+<li><h4>victimMessage</h4>
+           <h6>Description</h6>
+           <p>The message that will be sent to the victim.</p>
+           <h6>Default</h6>
+           <pre><code>null</code></pre></li></ul>
+        </details>
+
+<details>
           <summary>AutoKickUnassigned</summary>
           <h2>AutoKickUnassigned</h2>
           <p>The <code>AutoKickUnassigned</code> plugin will automatically kick players that are not in a squad after a specified ammount of time.</p>
@@ -501,151 +786,6 @@ Interested in creating your own plugin? [See more here](./squad-server/plugins/r
         </details>
 
 <details>
-          <summary>DiscordDebug</summary>
-          <h2>DiscordDebug</h2>
-          <p>The <code>DiscordDebug</code> plugin can be used to help debug SquadJS by dumping SquadJS events to a Discord channel.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log events to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>events (Required)</h4>
-           <h6>Description</h6>
-           <p>A list of events to dump.</p>
-           <h6>Default</h6>
-           <pre><code>[]</code></pre></li><h6>Example</h6>
-           <pre><code>[
-  "PLAYER_DIED"
-]</code></pre></ul>
-        </details>
-
-<details>
-          <summary>CBLInfo</summary>
-          <h2>CBLInfo</h2>
-          <p>The <code>CBLInfo</code> plugin alerts admins when a harmful player is detected joining their server based on data from the <a href="https://communitybanlist.com/">Community Ban List</a>.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to alert admins through.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>threshold</h4>
-           <h6>Description</h6>
-           <p>Admins will be alerted when a player has this or more reputation points. For more information on reputation points, see the <a href="https://communitybanlist.com/faq">Community Ban List's FAQ</a></p>
-           <h6>Default</h6>
-           <pre><code>6</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>SocketIOAPI</summary>
-          <h2>SocketIOAPI</h2>
-          <p>The <code>SocketIOAPI</code> plugin allows remote access to a SquadJS instance via Socket.IO<br />As a client example you can use this to connect to the socket.io server;<pre><code>
-      const socket = io.connect('ws://IP:PORT', {
-        auth: {
-          token: "MySecretPassword"
-        }
-      })
-    </code></pre>If you need more documentation about socket.io please go ahead and read the following;<br />General Socket.io documentation: <a href="https://socket.io/docs/v3" target="_blank">Socket.io Docs</a><br />Authentication and securing your websocket: <a href="https://socket.io/docs/v3/middlewares/#Sending-credentials" target="_blank">Sending-credentials</a><br />How to use, install and configure a socketIO-client: <a href="https://github.com/11TStudio/SocketIO-Examples-for-SquadJS" target="_blank">Usage Guide with Examples</a></p>
-          <h3>Options</h3>
-          <ul><li><h4>websocketPort (Required)</h4>
-           <h6>Description</h6>
-           <p>The port for the websocket.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>3000</code></pre>
-<li><h4>securityToken (Required)</h4>
-           <h6>Description</h6>
-           <p>Your secret token/password for connecting.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>MySecretPassword</code></pre></ul>
-        </details>
-
-<details>
-          <summary>DBLog</summary>
-          <h2>DBLog</h2>
-          <p>The <code>mysql-log</code> plugin will log various server statistics and events to a database. This is great for server performance monitoring and/or player stat tracking.
-
-Grafana:
-<ul><li> <a href="https://grafana.com/">Grafana</a> is a cool way of viewing server statistics stored in the database.</li>
-<li>Install Grafana.</li>
-<li>Add your database as a datasource named <code>SquadJS</code>.</li>
-<li>Import the <a href="https://github.com/Team-Silver-Sphere/SquadJS/blob/master/squad-server/templates/SquadJS-Dashboard-v2.json">SquadJS Dashboard</a> to get a preconfigured MySQL only Grafana dashboard.</li>
-<li>Install any missing Grafana plugins.</li></ul></p>
-          <h3>Options</h3>
-          <ul><li><h4>database (Required)</h4>
-           <h6>Description</h6>
-           <p>The Sequelize connector to log server information to.</p>
-           <h6>Default</h6>
-           <pre><code>mysql</code></pre></li>
-<li><h4>overrideServerID</h4>
-           <h6>Description</h6>
-           <p>A overridden server ID.</p>
-           <h6>Default</h6>
-           <pre><code>null</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordSquadCreated</summary>
-          <h2>DiscordSquadCreated</h2>
-          <p>The <code>SquadCreated</code> plugin will log Squad Creation events to a Discord channel.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The ID of the channel to log Squad Creation events to.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre>
-<li><h4>color</h4>
-           <h6>Description</h6>
-           <p>The color of the embed.</p>
-           <h6>Default</h6>
-           <pre><code>16761867</code></pre></li>
-<li><h4>useEmbed</h4>
-           <h6>Description</h6>
-           <p>Send message as Embed</p>
-           <h6>Default</h6>
-           <pre><code>true</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>ChatCommands</summary>
-          <h2>ChatCommands</h2>
-          <p>The <code>ChatCommands</code> plugin can be configured to make chat commands that broadcast or warn the caller with present messages.</p>
-          <h3>Options</h3>
-          <ul><li><h4>commands</h4>
-           <h6>Description</h6>
-           <p>An array of objects containing the following properties: <ul><li><code>command</code> - The command that initiates the message.</li><li><code>type</code> - Either <code>warn</code> or <code>broadcast</code>.</li><li><code>response</code> - The message to respond with.</li><li><code>ignoreChats</code> - A list of chats to ignore the commands in. Use this to limit it to admins.</li></ul></p>
-           <h6>Default</h6>
-           <pre><code>[
-  {
-    "command": "squadjs",
-    "type": "warn",
-    "response": "This server is powered by SquadJS.",
-    "ignoreChats": []
-  }
-]</code></pre></li></ul>
-        </details>
-
-<details>
           <summary>DiscordTeamkill</summary>
           <h2>DiscordTeamkill</h2>
           <p>The <code>DiscordTeamkill</code> plugin logs teamkills and related information to a Discord channel for admins to review.</p>
@@ -671,63 +811,6 @@ Grafana:
            <p>Disable Community Ban List information.</p>
            <h6>Default</h6>
            <pre><code>false</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>IntervalledBroadcasts</summary>
-          <h2>IntervalledBroadcasts</h2>
-          <p>The <code>IntervalledBroadcasts</code> plugin allows you to set broadcasts, which will be broadcasted at preset intervals</p>
-          <h3>Options</h3>
-          <ul><li><h4>broadcasts</h4>
-           <h6>Description</h6>
-           <p>Messages to broadcast.</p>
-           <h6>Default</h6>
-           <pre><code>[]</code></pre></li><h6>Example</h6>
-           <pre><code>[
-  "This server is powered by SquadJS."
-]</code></pre>
-<li><h4>interval</h4>
-           <h6>Description</h6>
-           <p>Frequency of the broadcasts in milliseconds.</p>
-           <h6>Default</h6>
-           <pre><code>300000</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordServerStatus</summary>
-          <h2>DiscordServerStatus</h2>
-          <p>The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>messageStore (Required)</h4>
-           <h6>Description</h6>
-           <p>Sequelize connector name.</p>
-           <h6>Default</h6>
-           <pre><code>sqlite</code></pre></li>
-<li><h4>command</h4>
-           <h6>Description</h6>
-           <p>Command name to get message.</p>
-           <h6>Default</h6>
-           <pre><code>!status</code></pre></li>
-<li><h4>disableSubscriptions</h4>
-           <h6>Description</h6>
-           <p>Whether to allow messages to be subscribed to automatic updates.</p>
-           <h6>Default</h6>
-           <pre><code>false</code></pre></li>
-<li><h4>updateInterval</h4>
-           <h6>Description</h6>
-           <p>How frequently to update the time in Discord.</p>
-           <h6>Default</h6>
-           <pre><code>60000</code></pre></li>
-<li><h4>setBotStatus</h4>
-           <h6>Description</h6>
-           <p>Whether to update the bot's status with server information.</p>
-           <h6>Default</h6>
-           <pre><code>true</code></pre></li></ul>
         </details>
 
 <details>
@@ -803,9 +886,9 @@ Grafana:
         </details>
 
 <details>
-          <summary>DiscordKillFeed</summary>
-          <h2>DiscordKillFeed</h2>
-          <p>The <code>DiscordKillFeed</code> plugin logs all wounds and related information to a Discord channel for admins to review.</p>
+          <summary>DiscordFOBHABExplosionDamage</summary>
+          <h2>DiscordFOBHABExplosionDamage</h2>
+          <p>The <code>DiscordFOBHABExplosionDamage</code> plugin logs damage done to FOBs and HABs by explosions to help identify engineers blowing up friendly FOBs and HABs.</p>
           <h3>Options</h3>
           <ul><li><h4>discordClient (Required)</h4>
            <h6>Description</h6>
@@ -814,7 +897,7 @@ Grafana:
            <pre><code>discord</code></pre></li>
 <li><h4>channelID (Required)</h4>
            <h6>Description</h6>
-           <p>The ID of the channel to log teamkills to.</p>
+           <p>The ID of the channel to log FOB/HAB explosion damage to.</p>
            <h6>Default</h6>
            <pre><code></code></pre></li><h6>Example</h6>
            <pre><code>667741905228136459</code></pre>
@@ -822,86 +905,7 @@ Grafana:
            <h6>Description</h6>
            <p>The color of the embeds.</p>
            <h6>Default</h6>
-           <pre><code>16761867</code></pre></li>
-<li><h4>disableCBL</h4>
-           <h6>Description</h6>
-           <p>Disable Community Ban List information.</p>
-           <h6>Default</h6>
-           <pre><code>false</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>AutoTKWarn</summary>
-          <h2>AutoTKWarn</h2>
-          <p>The <code>AutoTkWarn</code> plugin will automatically warn players with a message when they teamkill.</p>
-          <h3>Options</h3>
-          <ul><li><h4>attackerMessage</h4>
-           <h6>Description</h6>
-           <p>The message to warn attacking players with.</p>
-           <h6>Default</h6>
-           <pre><code>Please apologise for ALL TKs in ALL chat!</code></pre></li>
-<li><h4>victimMessage</h4>
-           <h6>Description</h6>
-           <p>The message that will be sent to the victim.</p>
-           <h6>Default</h6>
-           <pre><code>null</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordPlaceholder</summary>
-          <h2>DiscordPlaceholder</h2>
-          <p>The <code>DiscordPlaceholder</code> plugin allows you to make your bot create placeholder messages that can be used when configuring other plugins.</p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>command</h4>
-           <h6>Description</h6>
-           <p>Command to create Discord placeholder.</p>
-           <h6>Default</h6>
-           <pre><code>!placeholder</code></pre></li>
-<li><h4>channelID (Required)</h4>
-           <h6>Description</h6>
-           <p>The bot will only answer with a placeholder on this channel</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>FogOfWar</summary>
-          <h2>FogOfWar</h2>
-          <p>The <code>FogOfWar</code> plugin can be used to automate setting fog of war mode.</p>
-          <h3>Options</h3>
-          <ul><li><h4>mode</h4>
-           <h6>Description</h6>
-           <p>Fog of war mode to set.</p>
-           <h6>Default</h6>
-           <pre><code>1</code></pre></li>
-<li><h4>delay</h4>
-           <h6>Description</h6>
-           <p>Delay before setting fog of war mode.</p>
-           <h6>Default</h6>
-           <pre><code>10000</code></pre></li></ul>
-        </details>
-
-<details>
-          <summary>DiscordSubsystemRestarter</summary>
-          <h2>DiscordSubsystemRestarter</h2>
-          <p>The <code>DiscordSubSystemRestarter</code> plugin allows you to manually restart SquadJS subsystems in case an issues arises with them.<ul><li><code>!squadjs restartsubsystem rcon</code></li><li><code>!squadjs restartsubsystem logparser</code></li></ul></p>
-          <h3>Options</h3>
-          <ul><li><h4>discordClient (Required)</h4>
-           <h6>Description</h6>
-           <p>Discord connector name.</p>
-           <h6>Default</h6>
-           <pre><code>discord</code></pre></li>
-<li><h4>role (Required)</h4>
-           <h6>Description</h6>
-           <p>ID of role required to run the sub system restart commands.</p>
-           <h6>Default</h6>
-           <pre><code></code></pre></li><h6>Example</h6>
-           <pre><code>667741905228136459</code></pre></ul>
+           <pre><code>16761867</code></pre></li></ul>
         </details>
 
 <br>

--- a/config.json
+++ b/config.json
@@ -46,51 +46,14 @@
   },
   "plugins": [
     {
-      "plugin": "TeamRandomizer",
-      "enabled": true,
-      "command": "randomize"
-    },
-    {
-      "plugin": "DiscordAdminBroadcast",
+      "plugin": "DiscordAdminCamLogs",
       "enabled": false,
       "discordClient": "discord",
       "channelID": "",
       "color": 16761867
     },
     {
-      "plugin": "DiscordFOBHABExplosionDamage",
-      "enabled": true,
-      "discordClient": "discord",
-      "channelID": "",
-      "color": 16761867
-    },
-    {
-      "plugin": "DiscordRoundWinner",
-      "enabled": true,
-      "discordClient": "discord",
-      "channelID": "",
-      "color": 16761867
-    },
-    {
-      "plugin": "DiscordChat",
-      "enabled": true,
-      "discordClient": "discord",
-      "channelID": "",
-      "chatColors": {},
-      "color": 16761867,
-      "ignoreChats": [
-        "ChatSquad"
-      ]
-    },
-    {
-      "plugin": "DiscordRoundEnded",
-      "enabled": true,
-      "discordClient": "discord",
-      "channelID": "",
-      "color": 16761867
-    },
-    {
-      "plugin": "DiscordAdminCamLogs",
+      "plugin": "DiscordAdminBroadcast",
       "enabled": false,
       "discordClient": "discord",
       "channelID": "",
@@ -105,35 +68,32 @@
       "prependAdminNameInBroadcast": false
     },
     {
-      "plugin": "SeedingMode",
+      "plugin": "DiscordRoundWinner",
       "enabled": true,
-      "interval": 150000,
-      "seedingThreshold": 50,
-      "seedingMessage": "Seeding Rules Active! Fight only over the middle flags! No FOB Hunting!",
-      "liveEnabled": true,
-      "liveThreshold": 52,
-      "liveMessage": "Live!",
-      "waitOnNewGames": true,
-      "waitTimeOnNewGame": 30
+      "discordClient": "discord",
+      "channelID": "",
+      "color": 16761867
     },
     {
-      "plugin": "AutoKickUnassigned",
-      "enabled": true,
-      "warningMessage": "Join a squad, you are unassigned and will be kicked",
-      "kickMessage": "Unassigned - automatically removed",
-      "frequencyOfWarnings": 30,
-      "unassignedTimer": 360,
-      "playerThreshold": 93,
-      "roundStartDelay": 900,
-      "ignoreAdmins": false,
-      "ignoreWhitelist": false
-    },
-    {
-      "plugin": "DiscordDebug",
+      "plugin": "DiscordKillFeed",
       "enabled": false,
       "discordClient": "discord",
       "channelID": "",
-      "events": []
+      "color": 16761867,
+      "disableCBL": false
+    },
+    {
+      "plugin": "DiscordPlaceholder",
+      "enabled": true,
+      "discordClient": "discord",
+      "command": "!placeholder",
+      "channelID": ""
+    },
+    {
+      "plugin": "DBLog",
+      "enabled": false,
+      "database": "mysql",
+      "overrideServerID": null
     },
     {
       "plugin": "CBLInfo",
@@ -143,24 +103,11 @@
       "threshold": 6
     },
     {
-      "plugin": "SocketIOAPI",
-      "enabled": false,
-      "websocketPort": "",
-      "securityToken": ""
-    },
-    {
-      "plugin": "DBLog",
-      "enabled": false,
-      "database": "mysql",
-      "overrideServerID": null
-    },
-    {
-      "plugin": "DiscordSquadCreated",
-      "enabled": false,
+      "plugin": "DiscordRoundEnded",
+      "enabled": true,
       "discordClient": "discord",
       "channelID": "",
-      "color": 16761867,
-      "useEmbed": true
+      "color": 16761867
     },
     {
       "plugin": "ChatCommands",
@@ -175,20 +122,6 @@
       ]
     },
     {
-      "plugin": "DiscordTeamkill",
-      "enabled": true,
-      "discordClient": "discord",
-      "channelID": "",
-      "color": 16761867,
-      "disableCBL": false
-    },
-    {
-      "plugin": "IntervalledBroadcasts",
-      "enabled": false,
-      "broadcasts": [],
-      "interval": 300000
-    },
-    {
       "plugin": "DiscordServerStatus",
       "enabled": true,
       "discordClient": "discord",
@@ -197,6 +130,99 @@
       "disableSubscriptions": false,
       "updateInterval": 60000,
       "setBotStatus": true
+    },
+    {
+      "plugin": "TeamRandomizer",
+      "enabled": true,
+      "command": "randomize"
+    },
+    {
+      "plugin": "DiscordChat",
+      "enabled": true,
+      "discordClient": "discord",
+      "channelID": "",
+      "chatColors": {},
+      "color": 16761867,
+      "ignoreChats": [
+        "ChatSquad"
+      ]
+    },
+    {
+      "plugin": "SeedingMode",
+      "enabled": true,
+      "interval": 150000,
+      "seedingThreshold": 50,
+      "seedingMessage": "Seeding Rules Active! Fight only over the middle flags! No FOB Hunting!",
+      "liveEnabled": true,
+      "liveThreshold": 52,
+      "liveMessage": "Live!",
+      "waitOnNewGames": true,
+      "waitTimeOnNewGame": 30
+    },
+    {
+      "plugin": "DiscordDebug",
+      "enabled": false,
+      "discordClient": "discord",
+      "channelID": "",
+      "events": []
+    },
+    {
+      "plugin": "DiscordSubsystemRestarter",
+      "enabled": false,
+      "discordClient": "discord",
+      "role": ""
+    },
+    {
+      "plugin": "DiscordSquadCreated",
+      "enabled": false,
+      "discordClient": "discord",
+      "channelID": "",
+      "color": 16761867,
+      "useEmbed": true
+    },
+    {
+      "plugin": "FogOfWar",
+      "enabled": false,
+      "mode": 1,
+      "delay": 10000
+    },
+    {
+      "plugin": "IntervalledBroadcasts",
+      "enabled": false,
+      "broadcasts": [],
+      "interval": 300000
+    },
+    {
+      "plugin": "SocketIOAPI",
+      "enabled": false,
+      "websocketPort": "",
+      "securityToken": ""
+    },
+    {
+      "plugin": "AutoTKWarn",
+      "enabled": true,
+      "attackerMessage": "Please apologise for ALL TKs in ALL chat!",
+      "victimMessage": null
+    },
+    {
+      "plugin": "AutoKickUnassigned",
+      "enabled": true,
+      "warningMessage": "Join a squad, you are unassigned and will be kicked",
+      "kickMessage": "Unassigned - automatically removed",
+      "frequencyOfWarnings": 30,
+      "unassignedTimer": 360,
+      "playerThreshold": 93,
+      "roundStartDelay": 900,
+      "ignoreAdmins": false,
+      "ignoreWhitelist": false
+    },
+    {
+      "plugin": "DiscordTeamkill",
+      "enabled": true,
+      "discordClient": "discord",
+      "channelID": "",
+      "color": 16761867,
+      "disableCBL": false
     },
     {
       "plugin": "DiscordAdminRequest",
@@ -214,37 +240,11 @@
       "showInGameAdmins": true
     },
     {
-      "plugin": "DiscordKillFeed",
-      "enabled": false,
+      "plugin": "DiscordFOBHABExplosionDamage",
+      "enabled": true,
       "discordClient": "discord",
       "channelID": "",
-      "color": 16761867,
-      "disableCBL": false
-    },
-    {
-      "plugin": "AutoTKWarn",
-      "enabled": true,
-      "attackerMessage": "Please apologise for ALL TKs in ALL chat!",
-      "victimMessage": null
-    },
-    {
-      "plugin": "DiscordPlaceholder",
-      "enabled": true,
-      "discordClient": "discord",
-      "command": "!placeholder",
-      "channelID": ""
-    },
-    {
-      "plugin": "FogOfWar",
-      "enabled": false,
-      "mode": 1,
-      "delay": 10000
-    },
-    {
-      "plugin": "DiscordSubsystemRestarter",
-      "enabled": false,
-      "discordClient": "discord",
-      "role": ""
+      "color": 16761867
     }
   ],
   "logger": {

--- a/squad-server/factory.js
+++ b/squad-server/factory.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import {Client, Events, GatewayIntentBits} from 'discord.js';
+import { Client, Events, GatewayIntentBits } from 'discord.js';
 import sequelize from 'sequelize';
 import AwnAPI from './utils/awn-api.js';
 
@@ -103,16 +103,20 @@ export default class SquadServerFactory {
     Logger.verbose('SquadServerFactory', 1, `Starting ${type} connector ${connectorName}...`);
 
     if (type === 'discord') {
-      const connector = new Client({intents:[
+      const connector = new Client({
+        intents: [
           GatewayIntentBits.Guilds,
           GatewayIntentBits.GuildMessages,
           GatewayIntentBits.MessageContent,
-          GatewayIntentBits.GuildMembers,
-        ]});
-      connector.once(Events.ClientReady, readyClient => {console.log(`Ready! Logged in as ${readyClient.user.tag}`);});
+          GatewayIntentBits.GuildMembers
+        ]
+      });
+      connector.once(Events.ClientReady, (readyClient) => {
+        console.log(`Ready! Logged in as ${readyClient.user.tag}`);
+      });
       await connector.login(connectorConfig);
       // setup compatability with older plugins for message create event.
-      connector.on('messageCreate', message=>{
+      connector.on('messageCreate', (message) => {
         connector.emit('message', message);
       });
       return connector;

--- a/squad-server/package.json
+++ b/squad-server/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "axios": "^0.21.1",
+    "basic-ftp": "^4.6.6",
     "core": "1.0.0",
     "didyoumean": "^1.2.1",
     "discord.js": "^14.14.1",

--- a/squad-server/plugins/discord-base-plugin.js
+++ b/squad-server/plugins/discord-base-plugin.js
@@ -36,8 +36,8 @@ export default class DiscordBasePlugin extends BasePlugin {
     if (typeof message === 'object' && 'embed' in message) {
       message.embed.footer = message.embed.footer || { text: COPYRIGHT_MESSAGE };
       if (typeof message.embed.color === 'string')
-        message.embed.color = parseInt(message.embed.color,16);
-      message = {...message, embeds:[message.embed]};
+        message.embed.color = parseInt(message.embed.color, 16);
+      message = { ...message, embeds: [message.embed] };
     }
 
     await this.channel.send(message);

--- a/squad-server/plugins/discord-server-status.js
+++ b/squad-server/plugins/discord-server-status.js
@@ -54,7 +54,6 @@ export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
   }
 
   async generateMessage() {
-
     // Set player embed field.
     let players = '';
 
@@ -65,24 +64,25 @@ export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
     players += ` / ${this.server.publicSlots}`;
     if (this.server.reserveSlots > 0) players += ` (+${this.server.reserveSlots})`;
 
-    const layerName = this.server.currentLayer ? this.server.currentLayer.name : (await this.server.rcon.getCurrentMap()).layer;
+    const layerName = this.server.currentLayer
+      ? this.server.currentLayer.name
+      : (await this.server.rcon.getCurrentMap()).layer;
 
     // Clamp the ratio between 0 and 1 to avoid tinygradient errors.
     const ratio = this.server.a2sPlayerCount / (this.server.publicSlots + this.server.reserveSlots);
     const clampedRatio = Math.min(1, Math.max(0, ratio));
 
     // Set gradient embed color.
-    const color =
-      parseInt(
-        tinygradient([
-          { color: '#ff0000', pos: 0 },
-          { color: '#ffff00', pos: 0.5 },
-          { color: '#00ff00', pos: 1 }
-        ])
-          .rgbAt(clampedRatio)
-          .toHex(),
-        16
-      );
+    const color = parseInt(
+      tinygradient([
+        { color: '#ff0000', pos: 0 },
+        { color: '#ffff00', pos: 0.5 },
+        { color: '#00ff00', pos: 1 }
+      ])
+        .rgbAt(clampedRatio)
+        .toHex(),
+      16
+    );
 
     const embedobj = {
       title: this.server.serverName,
@@ -99,18 +99,21 @@ export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
         {
           name: 'Next Layer',
           value: `\`\`\`${
-            this.server.nextLayer?.name || (this.server.nextLayerToBeVoted ? 'To be voted' : 'Unknown')
+            this.server.nextLayer?.name ||
+            (this.server.nextLayerToBeVoted ? 'To be voted' : 'Unknown')
           }\`\`\``,
           inline: true
         }
       ],
       color: color,
-      footer: {text:COPYRIGHT_MESSAGE},
+      footer: { text: COPYRIGHT_MESSAGE },
       timestamp: new Date(),
       image: {
-        url: (this.server.currentLayer ? `https://squad-data.nyc3.cdn.digitaloceanspaces.com/main/${this.server.currentLayer.layerid}.jpg` : undefined)
-      },
-    }
+        url: this.server.currentLayer
+          ? `https://squad-data.nyc3.cdn.digitaloceanspaces.com/main/${this.server.currentLayer.layerid}.jpg`
+          : undefined
+      }
+    };
 
     return { embeds: [embedobj] };
   }

--- a/squad-server/templates/readme-template.md
+++ b/squad-server/templates/readme-template.md
@@ -84,6 +84,10 @@ The following section of the configuration contains information about your Squad
       {
         "type": "remote",
         "source": "http://yourWebsite.com/Server1/Admins.cfg",
+      },
+      {
+        "type": "ftp",
+        "source": "ftp://<user>:<password>@<host>:<port>/<url-path>",
       }
     ]
   },

--- a/squad-server/utils/admin-lists.js
+++ b/squad-server/utils/admin-lists.js
@@ -34,7 +34,7 @@ export default async function fetchAdminLists(adminLists) {
           break;
         }
         case 'ftp': {
-          // ex uri:  ftp://username:password@host:21/some/file.txt
+          // ex url: ftp//<user>:<password>@<host>:<port>/<url-path>
           if (!list.source.startsWith('ftp://')) {
             throw new Error(`Invalid FTP URI format of ${list.source}. The source must be a FTP URI starting with the protocol. Ex: ftp://username:password@host:21/some/file.txt`)
           }
@@ -44,27 +44,11 @@ export default async function fetchAdminLists(adminLists) {
           const remoteFilePath = pathStartIndex === -1 ? "/" : hostPathString.substring(pathStartIndex)
           const [host, port = 21] = hostPathString.substring(0, pathStartIndex === -1 ? hostPathString.length : pathStartIndex).split(":")
 
-          console.log("ftp debug loginString", loginString)
-          console.log("ftp debug hostPathString", hostPathString)
-          console.log("ftp debug user", user)
-          console.log("ftp debug password", password)
-          console.log("ftp debug pathStartIndex", pathStartIndex)
-          console.log("ftp debug remoteFilePath", remoteFilePath)
-          console.log("ftp debug host", host)
-          console.log("ftp debug port", port)
-
           const buffer = new WritableBuffer()
           const ftpClient = new FTPClient()
-          await ftpClient.access({
-            host,
-            port,
-            user,
-            password
-          })
+          await ftpClient.access({ host, port, user, password })
           await ftpClient.downloadTo(buffer, remoteFilePath)
-          const bufData = buffer.toString("utf8")
-          console.log("ftp debug buffer", bufData)
-          data = bufData
+          data = buffer.toString("utf8")
           break
         }
         default:

--- a/squad-server/utils/admin-lists.js
+++ b/squad-server/utils/admin-lists.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { Client as FTPClient } from 'basic-ftp'
+import WritableBuffer from "./writable-buffer.js"
 
 import axios from 'axios';
 import Logger from 'core/logger';
@@ -30,6 +32,40 @@ export default async function fetchAdminLists(adminLists) {
           if (!fs.existsSync(listPath)) throw new Error(`Could not find Admin List at ${listPath}`);
           data = fs.readFileSync(listPath, 'utf8');
           break;
+        }
+        case 'ftp': {
+          // ex uri:  ftp://username:password@host:21/some/file.txt
+          if (!list.source.startsWith('ftp://')) {
+            throw new Error(`Invalid FTP URI format of ${list.source}. The source must be a FTP URI starting with the protocol. Ex: ftp://username:password@host:21/some/file.txt`)
+          }
+          const [loginString, hostPathString] = list.source.substring('ftp://'.length).split("@")
+          const [user, password] = loginString.split(":").map(v => decodeURI(v))
+          const pathStartIndex = hostPathString.indexOf("/")
+          const remoteFilePath = pathStartIndex === -1 ? "/" : hostPathString.substring(pathStartIndex)
+          const [host, port = 21] = hostPathString.substring(0, pathStartIndex === -1 ? hostPathString.length : pathStartIndex).split(":")
+
+          console.log("ftp debug loginString", loginString)
+          console.log("ftp debug hostPathString", hostPathString)
+          console.log("ftp debug user", user)
+          console.log("ftp debug password", password)
+          console.log("ftp debug pathStartIndex", pathStartIndex)
+          console.log("ftp debug remoteFilePath", remoteFilePath)
+          console.log("ftp debug host", host)
+          console.log("ftp debug port", port)
+
+          const buffer = new WritableBuffer()
+          const ftpClient = new FTPClient()
+          await ftpClient.access({
+            host,
+            port,
+            user,
+            password
+          })
+          await ftpClient.downloadTo(buffer, remoteFilePath)
+          const bufData = buffer.toString("utf8")
+          console.log("ftp debug buffer", bufData)
+          data = bufData
+          break
         }
         default:
           throw new Error(`Unsupported AdminList type:${list.type}`);

--- a/squad-server/utils/admin-lists.js
+++ b/squad-server/utils/admin-lists.js
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { Client as FTPClient } from 'basic-ftp'
-import WritableBuffer from "./writable-buffer.js"
+import { Client as FTPClient } from 'basic-ftp';
+import WritableBuffer from './writable-buffer.js';
 
 import axios from 'axios';
 import Logger from 'core/logger';
@@ -36,20 +36,25 @@ export default async function fetchAdminLists(adminLists) {
         case 'ftp': {
           // ex url: ftp//<user>:<password>@<host>:<port>/<url-path>
           if (!list.source.startsWith('ftp://')) {
-            throw new Error(`Invalid FTP URI format of ${list.source}. The source must be a FTP URI starting with the protocol. Ex: ftp://username:password@host:21/some/file.txt`)
+            throw new Error(
+              `Invalid FTP URI format of ${list.source}. The source must be a FTP URI starting with the protocol. Ex: ftp://username:password@host:21/some/file.txt`
+            );
           }
-          const [loginString, hostPathString] = list.source.substring('ftp://'.length).split("@")
-          const [user, password] = loginString.split(":").map(v => decodeURI(v))
-          const pathStartIndex = hostPathString.indexOf("/")
-          const remoteFilePath = pathStartIndex === -1 ? "/" : hostPathString.substring(pathStartIndex)
-          const [host, port = 21] = hostPathString.substring(0, pathStartIndex === -1 ? hostPathString.length : pathStartIndex).split(":")
+          const [loginString, hostPathString] = list.source.substring('ftp://'.length).split('@');
+          const [user, password] = loginString.split(':').map((v) => decodeURI(v));
+          const pathStartIndex = hostPathString.indexOf('/');
+          const remoteFilePath =
+            pathStartIndex === -1 ? '/' : hostPathString.substring(pathStartIndex);
+          const [host, port = 21] = hostPathString
+            .substring(0, pathStartIndex === -1 ? hostPathString.length : pathStartIndex)
+            .split(':');
 
-          const buffer = new WritableBuffer()
-          const ftpClient = new FTPClient()
-          await ftpClient.access({ host, port, user, password })
-          await ftpClient.downloadTo(buffer, remoteFilePath)
-          data = buffer.toString("utf8")
-          break
+          const buffer = new WritableBuffer();
+          const ftpClient = new FTPClient();
+          await ftpClient.access({ host, port, user, password });
+          await ftpClient.downloadTo(buffer, remoteFilePath);
+          data = buffer.toString('utf8');
+          break;
         }
         default:
           throw new Error(`Unsupported AdminList type:${list.type}`);

--- a/squad-server/utils/writable-buffer.js
+++ b/squad-server/utils/writable-buffer.js
@@ -1,0 +1,22 @@
+import { Writable } from "stream";
+
+export class WritableBuffer extends Writable {
+  constructor(options) {
+    super(options);
+    this.data = [];
+  }
+
+  _write(chunk, encoding, callback) {
+    this.data.push(chunk);
+    callback();
+  }
+
+  getBuffer() {
+    return Buffer.concat(this.data);
+  }
+
+  toString(encoding = "utf8") {
+    return this.getBuffer().toString(encoding);
+  }
+}
+export default WritableBuffer

--- a/squad-server/utils/writable-buffer.js
+++ b/squad-server/utils/writable-buffer.js
@@ -1,4 +1,4 @@
-import { Writable } from "stream";
+import { Writable } from 'stream';
 
 export class WritableBuffer extends Writable {
   constructor(options) {
@@ -15,8 +15,8 @@ export class WritableBuffer extends Writable {
     return Buffer.concat(this.data);
   }
 
-  toString(encoding = "utf8") {
+  toString(encoding = 'utf8') {
     return this.getBuffer().toString(encoding);
   }
 }
-export default WritableBuffer
+export default WritableBuffer;


### PR DESCRIPTION
The admin-list system now supports loading the Admins.cfg file via FTP, significantly improving compatibility with game server providers. By setting the admin-list configuration type to ftp and providing an FTP URL as the source, the Admins.cfg file will be downloaded into a buffer and parsed by the rest of the system.

```json
    {
        "type": "ftp",
        "source": "ftp://<user>:<password>@<host>:<port>/<url-path>"
      }
```