### PR TITLE
Support empty team names

### DIFF
--- a/squad-server/rcon.js
+++ b/squad-server/rcon.js
@@ -183,7 +183,7 @@ export default class SquadRcon extends Rcon {
       const match = line.match(
         /ID: (?<squadID>\d+) \| Name: (?<squadName>.+) \| Size: (?<size>\d+) \| Locked: (?<locked>True|False) \| Creator Name: (?<creatorName>.+) \| Creator Online IDs:([^|]+)/
       );
-      const matchSide = line.match(/Team ID: (\d) \((.+)\)/);
+      const matchSide = line.match(/Team ID: (\d) \((.*)\)/);
       if (matchSide) {
         teamID = +matchSide[1];
         teamName = matchSide[2];


### PR DESCRIPTION
Some mods can have empty team names. The current regular expression to enforces at least one character in the team name. This PR removes the requirement, thus supporting empty team names instead of failing to parse the entire row.