### PR TITLE
Support for fetching admin list from SFTP source

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The following section of the configuration contains information about your Squad
 * `rconPassword` - The RCON password of the server.
 * `logReaderMode` - `tail` will read from a local log file, `ftp` will read from a remote log file using the FTP protocol, `sftp` will read from a remote log file using the SFTP protocol.
 * `logDir` - The folder where your Squad logs are saved. Most likely will be `C:/servers/squad_server/SquadGame/Saved/Logs`.
-* `ftp` - FTP configuration for reading logs remotely.
-* `sftp` - SFTP configuration for reading logs remotely.
+* `ftp` - FTP configuration for reading logs remotely. Only required for `ftp` `logReaderMode`.
+* `sftp` - SFTP configuration for reading logs remotely. Only required for `sftp` `logReaderMode`.
 * `adminLists` - Sources for identifying an admins on the server, either remote or local.
 
   ---

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "type": "module",
   "dependencies": {
-    "squad-server": "1.0.0"
+    "squad-server": "1.0.0",
+    "ssh2-sftp-client": "^11.0.0"
   },
   "devDependencies": {
     "eslint": "^7.17.0",


### PR DESCRIPTION
This PR adds support for fetching Admins.cfg file from SFTP source. I have also replaced manual regex based URL parsing with NodeJS's URL parsing.

I have tested both FTP and SFTP using local docker containers (https://github.com/garethflowers/docker-ftp-server and https://docs.sftpgo.com/).

I have used `ssh2-sftp-client` package because this exact package is being used by the current ftp-tail dependency (https://github.com/Thomas-Smyth/ftp-tail/). The major version is increased from 10 to 11, but I don't think that should break anything.