### PR TITLE
feat: hide prod configs from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tmp
 
 config-test*.json
+config.*.json
 
 # Dependencies
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.tmp
 
 config-test*.json
-config.*.json
+/configs
 
 # Dependencies
 node_modules/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "configs"]
+	path = configs
+	url = ./configs


### PR DESCRIPTION
Allow the creation of configs in git submodule locally.

```
cd YOUR_MAIN_REPO
mkdir configs
cd configs/
git init
touch config.main_server_1.conf
git add .
git commit -m "init: add config for first server"
cd ..
git submodule add ./configs configs
```