### PR TITLE
Fix new-game.js - properly match DLC names

### DIFF
--- a/squad-server/log-parser/new-game.js
+++ b/squad-server/log-parser/new-game.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogWorld: Bringing World \/([A-z]+)\/(?:Maps\/)?([A-z0-9-]+)\/(?:.+\/)?([A-z0-9-]+)(?:\.[A-z0-9-]+)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogWorld: Bringing World \/([A-z0-9_-]+)\/(?:Maps\/)?([A-z0-9-]+)\/(?:.+\/)?([A-z0-9-]+)(?:\.[A-z0-9-]+)/,
   onMatch: (args, logParser) => {
     if (args[5] === 'TransitionMap') {
       return;


### PR DESCRIPTION
TitanLeague for example:
`[2025.01.31-09.45.27:921][378]LogWorld: Bringing World /TitanLeagueMod_44th/Maps/Anvil/Gameplay_Layers/TL_Anvilv1.TL_Anvilv1 up for play (max tick rate 40) at 2025.01.31-11.45.27` old capture group was for `A-z`. New for `A-z0-9-_`

_This time not syncing master._