### PR TITLE
fix: improve player connection log parsing regex for mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The following section of the configuration contains information about your Squad
 * `rconPassword` - The RCON password of the server.
 * `logReaderMode` - `tail` will read from a local log file, `ftp` will read from a remote log file using the FTP protocol, `sftp` will read from a remote log file using the SFTP protocol.
 * `logDir` - The folder where your Squad logs are saved. Most likely will be `C:/servers/squad_server/SquadGame/Saved/Logs`.
-* `ftp` - FTP configuration for reading logs remotely.
-* `sftp` - SFTP configuration for reading logs remotely.
+* `ftp` - FTP configuration for reading logs remotely. Only required for `ftp` `logReaderMode`.
+* `sftp` - SFTP configuration for reading logs remotely. Only required for `sftp` `logReaderMode`.
 * `adminLists` - Sources for identifying an admins on the server, either remote or local.
 
   ---

--- a/squad-server/log-parser/player-connected.js
+++ b/squad-server/log-parser/player-connected.js
@@ -2,7 +2,7 @@ import { iterateIDs, lowerID } from 'core/id-parser';
 
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController[^\s]+ .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
   onMatch: (args, logParser) => {
     const IDs = {};
     iterateIDs(args[5]).forEach((platform, id) => {


### PR DESCRIPTION
Examples:

```
[2025.02.08-07.00.31:552][226]LogSquad: PostLogin: NewPlayer: BP_PlayerController_SATSeed_C /SquadAdminTools/Maps/SATSeed/Maps/Tallil/L_SAT_Tallil_Seed_v1.L_SAT_Tallil_Seed_v1:PersistentLevel.BP_PlayerController_SATSeed_C_2147480569 (IP: 1.1.1.1 | Online IDs: EOS: 00029de38ed043fa95b533aaaaa00000 steam: 76561198831400000)

[2025.02.08-10.34.30:881][672]LogSquad: PostLogin: NewPlayer: BP_PlayerController_AdminTools_C /Game/Maps/Mutaha/Gameplay_Layers/Mutaha_AAS_v1.Mutaha_AAS_v1:PersistentLevel.BP_PlayerController_AdminTools_C_2146458266 (IP: 1.1.1.1 | Online IDs: EOS: 0002365f5f9e4221a0bc22aaaaa00000 steam: 76561198380000000)
```