### PR TITLE
Fix player-connected and player-disconnected for modded maps

### DIFF
--- a/squad-server/log-parser/player-connected.js
+++ b/squad-server/log-parser/player-connected.js
@@ -2,7 +2,7 @@ import { iterateIDs, lowerID } from 'core/id-parser';
 
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController(?:|.+)_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
   onMatch: (args, logParser) => {
     const IDs = {};
     iterateIDs(args[5]).forEach((platform, id) => {

--- a/squad-server/log-parser/player-disconnected.js
+++ b/squad-server/log-parser/player-disconnected.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogNet: UChannel::Close: Sending CloseBunch\. ChIndex == [0-9]+\. Name: \[UChannel\] ChIndex: [0-9]+, Closing: [0-9]+ \[UNetConnection\] RemoteAddr: ([\d.]+):[\d]+, Name: EOSIpNetConnection_[0-9]+, Driver: GameNetDriver EOSNetDriver_[0-9]+, IsServer: YES, PC: ([^ ]+PlayerController_C_[0-9]+), Owner: [^ ]+PlayerController_C_[0-9]+, UniqueId: RedpointEOS:([\d\w]+)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogNet: UChannel::Close: Sending CloseBunch\. ChIndex == [0-9]+\. Name: \[UChannel\] ChIndex: [0-9]+, Closing: [0-9]+ \[UNetConnection\] RemoteAddr: ([\d.]+):[\d]+, Name: EOSIpNetConnection_[0-9]+, Driver: GameNetDriver EOSNetDriver_[0-9]+, IsServer: YES, PC: ([^ ]+PlayerController(?:|.+)_C_[0-9]+), Owner: [^ ]+PlayerController(?:|.+)_C_[0-9]+, UniqueId: RedpointEOS:([\d\w]+)/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],


### PR DESCRIPTION
Fixes _player-connected.js_ and _player-disconnected.js_ to properly catch logs from modded maps, where player controller is named a bit differently.
Log examples 
- (Player connected): 
`[2025.02.09-17.48.54:738][ 87]LogSquad: PostLogin: NewPlayer: BP_PlayerController_SMT_C /TitanLeagueMod_44th/Maps/Narva/Gameplay_Layers/TL_narvav1.TL_narvav1:PersistentLevel.BP_PlayerController`**`_SMT`**`_C_0000000000 (IP: 0.0.0.0 | Online IDs: EOS: 00000000000000000000000000000000 steam: 00000000000000000)`

- (Player disconnected):
`[2025.02.09-19.51.07:026][108]LogNet: UChannel::Close: Sending CloseBunch. ChIndex == 0. Name: [UChannel] ChIndex: 0, Closing: 0 [UNetConnection] RemoteAddr: 0.0.0.0:0, Name: EOSIpNetConnection_0000000000, Driver: GameNetDriver EOSNetDriver_0000000000, IsServer: YES, PC: BP_PlayerController`**`_SMT`**`_C_0000000000, Owner: BP_PlayerController`**`_SMT`**`_C_0000000000, UniqueId: RedpointEOS:00000000000000000000000000000000`