### PR TITLE
Added new plugin to enforce squadleader take SL kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,55 @@ Grafana:
            <h6>Default</h6>
            <pre><code>false</code></pre></li></ul>
         </details>
+<details>
+  <summary>EnforceSquadLeaderKit</summary>
+  <h2>EnforceSquadLeaderKit</h2>
+  <p>The <code>EnforceSquadLeaderKit</code> plugin ensures that squad leaders select the correct Squad Leader kit. It will warn players who do not comply and disband their squad if they fail to switch after multiple warnings.</p>
 
+  <h3>Options</h3>
+  <ul>
+    <li>
+      <h4>warningMessage</h4>
+      <h6>Description</h6>
+      <p>Message displayed to squad leaders warning them to take the correct kit.</p>
+      <h6>Default</h6>
+      <pre><code>You must take the Squad Leader kit, or your squad will be disbanded!</code></pre>
+    </li>
+
+    <li>
+      <h4>checkInterval</h4>
+      <h6>Description</h6>
+      <p>Interval (in seconds) to check all squad leaders for the correct kit.</p>
+      <h6>Default</h6>
+      <pre><code>30</code></pre>
+    </li>
+
+    <li>
+      <h4>maxWarnings</h4>
+      <h6>Description</h6>
+      <p>Number of warnings a squad leader receives before their squad is disbanded.</p>
+      <h6>Default</h6>
+      <pre><code>3</code></pre>
+    </li>
+  </ul>
+
+  <h3>Behavior</h3>
+  <ul>
+    <li>Automatically monitors squad leaders at the specified interval.</li>
+    <li>Warns squad leaders if they do not have the correct kit.</li>
+    <li>Disbands a squad after a configurable number of warnings.</li>
+    <li>Resets warnings if the player takes the correct kit.</li>
+  </ul>
+
+  <h3>Example Configuration</h3>
+  <pre><code>{
+  "plugin": "EnforceSquadLeaderKit",
+  "enabled": true,
+  "warningMessage": "You must take the Squad Leader kit, or your squad will be disbanded!",
+  "checkInterval": 30,
+  "maxWarnings": 3
+}</code></pre>
+</details>
 <details>
           <summary>FogOfWar</summary>
           <h2>FogOfWar</h2>

--- a/config.json
+++ b/config.json
@@ -212,6 +212,14 @@
       "color": 16761867,
       "disableCBL": false
     },
+	{
+      "plugin": "EnforceSquadLeaderKit",
+      "enabled": true,
+      "warningMessage": "You must take the Squad Leader kit, or your squad will be disbanded!",
+      "warningTimeout": 30,
+      "checkInterval": 30,
+      "maxWarnings": 10
+    },
     {
       "plugin": "FogOfWar",
       "enabled": false,

--- a/squad-server/plugins/enforce-squad-leader-kit.js
+++ b/squad-server/plugins/enforce-squad-leader-kit.js
@@ -1,0 +1,70 @@
+import BasePlugin from './base-plugin.js';
+
+export default class EnforceSquadLeaderKit extends BasePlugin {
+  static get description() {
+    return 'Ensures squad leaders take the correct Squad Leader kit, warns them if they do not, and disbands the squad if they fail to comply.';
+  }
+
+  static get defaultEnabled() {
+    return true;
+  }
+
+  static get optionsSpecification() {
+    return {
+      warningMessage: {
+        required: false,
+        description: 'Warning message for squad leaders without the correct kit.',
+        default: 'You must take the Squad Leader kit, or your squad will be disbanded!'
+      },
+      checkInterval: {
+        required: false,
+        description: 'Interval (in seconds) to check all squad leaders.',
+        default: 30
+      },
+      maxWarnings: {
+        required: false,
+        description: 'Number of warnings before disbanding the squad.',
+        default: 3
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+    this.warningCounts = {};
+    this.checkSquadLeaders = this.checkSquadLeaders.bind(this);
+  }
+
+  async mount() {
+    this.checkInterval = setInterval(this.checkSquadLeaders, this.options.checkInterval * 1000);
+  }
+
+  async unmount() {
+    clearInterval(this.checkInterval);
+  }
+
+  async checkSquadLeaders() {
+    for (const player of this.server.players) {
+      if (player.isLeader) {
+        if (!player.role.includes('SL')) {
+          this.issueWarning(player);
+        } else if (this.warningCounts[player.steamID]) {
+          this.server.rcon.warn(player.steamID, "Thank you for taking the correct kit!");
+          this.warningCounts[player.steamID] = 0;
+        }
+      }
+    }
+  }
+
+  async issueWarning(player) {
+    const warnings = this.warningCounts[player.steamID] || 0;
+    this.warningCounts[player.steamID] = warnings + 1;
+
+    this.server.rcon.warn(player.steamID, `${this.options.warningMessage} (${warnings + 1}/${this.options.maxWarnings})`);
+
+    if (this.warningCounts[player.steamID] >= this.options.maxWarnings) {
+      this.server.rcon.execute(`AdminDisbandSquad ${player.teamID} ${player.squadID}`);
+      this.warningCounts[player.steamID] = 0;
+    }
+  }
+}


### PR DESCRIPTION
The **EnforceSquadLeaderKit** plugin was created to maintain structured and effective team gameplay in Squad servers. It ensures that squad leaders comply with the requirement of selecting the proper Squad Leader kit, a role essential for efficient communication and coordination during matches.

### **Purpose and Features**

This plugin automatically monitors squad leaders and provides the following functionalities:

- **Warning System:** Issues configurable warnings when squad leaders do not have the correct Squad Leader kit.
- **Automatic Squad Disbanding:** If a squad leader ignores warnings and fails to switch to the appropriate kit, the plugin disbands their squad.
- **Warning Reset:** Warnings are cleared if the player selects the correct kit after receiving a notice.

### **Why Use This Plugin?**

- **Enhanced Team Coordination:** Ensuring squad leaders have the right kits improves communication and combat efficiency.
- **Automated Monitoring:** Reduces the administrative workload for server moderators by automating checks and compliance enforcement.
- **Configurable Behavior:** Offers flexibility through customizable warning messages, intervals, and thresholds.

This plugin was designed to encourage responsible gameplay and maintain a positive experience for all players by enforcing squad leader role compliance.