### PR TITLE
Fix Regex detection for new games for modded layers

### DIFF
--- a/squad-server/log-parser/new-game.js
+++ b/squad-server/log-parser/new-game.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogWorld: Bringing World \/([A-z]+)\/(?:Maps\/)?([A-z0-9-]+)\/(?:.+\/)?([A-z0-9-]+)(?:\.[A-z0-9-]+)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogWorld: Bringing World \/([A-z0-9]+)\/(?:Maps\/)?([A-z0-9-]+)\/(?:.+\/)?([A-z0-9-]+)(?:\.[A-z0-9-]+)/,
   onMatch: (args, logParser) => {
     if (args[5] === 'TransitionMap') {
       return;


### PR DESCRIPTION
**Problem**
New game is not detected for the following log line:
`[2025.02.22-22.42.54:323][177]LogWorld: Bringing World /TitanLeagueMod_44th/Maps/Sumari/Gameplay_Layers/TL_sumariv1_S2.TL_sumariv1_S2 up for play (max tick rate 64) at 2025.02.22-23.42.54`

This is due to that `TitanLeagueMod_44th` isn't allowed any numbers. 

**Solution**

With this fix, it allows the use of numbers in that part as well.
