### PR TITLE
Refactor SquadLogParser to dynamically load parser files

### DIFF
--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import LogParser from 'core/log-parser';
-import Logger from 'core/logger.js';
+import Logger from 'core/logger';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -11,7 +11,12 @@ export default class SquadLogParser extends LogParser {
   constructor(options) {
     super('SquadGame.log', options);
     this._rules = [];
-    this.setupRules();
+  }
+
+  async watch() {
+    //? Wait for rules to be configured before hooking the log file
+    await this.setupRules();
+    return super.watch();
   }
 
   async setupRules() {

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import LogParser from 'core/log-parser';
-import Logger from '../../core/logger.js';
+import Logger from 'core/logger.js';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -10,8 +10,14 @@ export default class SquadLogParser extends LogParser {
   constructor(options) {
     super('SquadGame.log', options);
     this._rules = [];
-    this.setupRules();
   }
+
+  async watch() {
+    //? Wait for rules to be configured before hooking the log file
+    await this.setupRules();
+    return super.watch();
+  }
+
 
   async setupRules() {
     const files = await fs.promises.opendir(path.resolve(path.join(__dirname, './')));

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import LogParser from 'core/log-parser';
-import Logger from '../../core/logger.js';
+import Logger from 'core/logger';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -1,44 +1,33 @@
-import LogParser from 'core/log-parser';
+import fs from 'fs';
+import path from 'path';
 
-import AdminBroadcast from './admin-broadcast.js';
-import DeployableDamaged from './deployable-damaged.js';
-import NewGame from './new-game.js';
-import PlayerConnected from './player-connected.js';
-import PlayerDisconnected from './player-disconnected.js';
-import PlayerDamaged from './player-damaged.js';
-import PlayerDied from './player-died.js';
-import PlayerPossess from './player-possess.js';
-import PlayerRevived from './player-revived.js';
-import PlayerUnPossess from './player-un-possess.js';
-import PlayerWounded from './player-wounded.js';
-import RoundEnded from './round-ended.js';
-import RoundTickets from './round-tickets.js';
-import RoundWinner from './round-winner.js';
-import ServerTickRate from './server-tick-rate.js';
-import PlayerJoinSucceeded from './player-join-succeeded.js';
+import LogParser from 'core/log-parser';
+import Logger from '../../core/logger.js';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default class SquadLogParser extends LogParser {
   constructor(options) {
     super('SquadGame.log', options);
+    this._rules = [];
+    this.setupRules();
   }
 
+  async setupRules() {
+    const files = await fs.promises.opendir(path.join(__dirname, './'));
+    for await (const file of files) {
+      if (!file.isFile() || !file.name.endsWith('.js')) continue;
+      Logger.verbose('SquadLogParser', 1, `Loading parser file ${file.name}...`);
+      const module = await import(path.join(__dirname, file.name));
+      if ('default' in module && 'regex' in module.default && 'onMatch' in module.default) {
+        this._rules.push(module.default);
+      }
+    }
+  }
+
+  // This should use a Loader in Vanilla SquadJS
   getRules() {
-    return [
-      AdminBroadcast,
-      DeployableDamaged,
-      NewGame,
-      PlayerConnected,
-      PlayerDisconnected,
-      PlayerDamaged,
-      PlayerDied,
-      PlayerPossess,
-      PlayerRevived,
-      PlayerUnPossess,
-      PlayerWounded,
-      RoundEnded,
-      RoundTickets,
-      RoundWinner,
-      ServerTickRate,
-      PlayerJoinSucceeded
-    ];
+    return this._rules;
   }
 }

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -2,35 +2,30 @@ import fs from 'fs';
 import path from 'path';
 
 import LogParser from 'core/log-parser';
-import Logger from 'core/logger';
-import { fileURLToPath } from 'url';
+import Logger from '../../core/logger.js';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 export default class SquadLogParser extends LogParser {
   constructor(options) {
     super('SquadGame.log', options);
     this._rules = [];
-  }
-
-  async watch() {
-    //? Wait for rules to be configured before hooking the log file
-    await this.setupRules();
-    return super.watch();
+    this.setupRules();
   }
 
   async setupRules() {
-    const files = await fs.promises.opendir(path.join(__dirname, './'));
+    const files = await fs.promises.opendir(path.resolve(path.join(__dirname, './')));
     for await (const file of files) {
       if (!file.isFile() || !file.name.endsWith('.js')) continue;
       Logger.verbose('SquadLogParser', 1, `Loading parser file ${file.name}...`);
-      const module = await import(path.join(__dirname, file.name));
+      const module = await import(pathToFileURL(path.join(__dirname, file.name)).href);
       if ('default' in module && 'regex' in module.default && 'onMatch' in module.default) {
         this._rules.push(module.default);
       }
     }
   }
 
+  // This should use a Loader in Vanilla SquadJS
   getRules() {
     return this._rules;
   }

--- a/squad-server/log-parser/index.js
+++ b/squad-server/log-parser/index.js
@@ -26,7 +26,6 @@ export default class SquadLogParser extends LogParser {
     }
   }
 
-  // This should use a Loader in Vanilla SquadJS
   getRules() {
     return this._rules;
   }


### PR DESCRIPTION
Refactored the log parser to find and load all parsers in log-parser folder on startup.

This allows custom log parsers and events to be dropped-in for a variety of things, mainly Mods.
Changes stemmed from needing some custom parsers for the [King of the Hill](https://steamcommunity.com/sharedfiles/filedetails/?id=3443779816) gamemode, which has some special logging to trigger events.

Tested on `(AFO) Noobs & Boobs`

<img width="480" height="322" alt="image" src="https://github.com/user-attachments/assets/129b8951-dc92-4e9d-bae2-cc0990724056" />
<img width="1177" height="31" alt="image" src="https://github.com/user-attachments/assets/7bf7f276-4bd8-444d-8dd4-15c5dd78977c" />
