### PR TITLE
Updated the Server Status in Discord , & FOB Explosions plugins to both Support GE MOD

### DIFF
--- a/config.json
+++ b/config.json
@@ -179,7 +179,7 @@
       "discordClient": "discord",
       "channelID": "",
       "color": 16761867
-    },
+    ,
     {
       "plugin": "DiscordServerStatus",
       "enabled": true,
@@ -187,8 +187,11 @@
       "messageStore": "sqlite",
       "command": "!status",
       "disableSubscriptions": false,
-      "updateInterval": 60000,
-      "setBotStatus": true
+      "updateInterval": 6000,
+      "setBotStatus": true,
+      "channelId": "",
+      "layerTagId": "SERVER2",
+      "resendIntervalMinutes": 10,
     },
     {
       "plugin": "DiscordSquadCreated",

--- a/config.json
+++ b/config.json
@@ -141,7 +141,7 @@
       "enabled": true,
       "discordClient": "discord",
       "channelID": "",
-      "color": 16761867
+      "color": 16761867,
     },
     {
       "plugin": "DiscordKillFeed",

--- a/squad-server/log-parser/deployable-damaged.js
+++ b/squad-server/log-parser/deployable-damaged.js
@@ -1,21 +1,24 @@
 export default {
-  regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquadTrace: \[DedicatedServer](?:ASQDeployable::)?TakeDamage\(\): ([A-z0-9_]+)_C_[0-9]+: ([0-9.]+) damage attempt by causer ([A-z0-9_]+)_C_[0-9]+ instigator (.+) with damage type ([A-z0-9_]+)_C health remaining ([0-9.]+)/,
+  regex: /^\[([0-9.:-]+)]\[([0-9]+)]LogSquadTrace: \[DedicatedServer\]TakeDamage\(\): ([A-Za-z0-9_]+)_C_[0-9]+: ([0-9.]+) damage (?:taken|attempt) by causer ([A-Za-z0-9_]+)_C_[0-9]+ instigator ([^()]+?)(?: \(Online IDs: EOS: ([a-f0-9]+) steam: (\d+)\))?(?: with damage type ([A-Za-z0-9_]+)_C)? health remaining ([0-9.]+)/,
+
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],
-      time: args[1],
+      time: new Date(),
       chainID: args[2],
       deployable: args[3],
       damage: parseFloat(args[4]),
       weapon: args[5],
-      playerSuffix: args[6],
-      damageType: args[7],
-      healthRemaining: args[8]
+      player: {
+        name: args[6]?.trim() || 'Unknown',
+        eosID: args[7] || null,
+        steamID: args[8] || null
+      },
+      damageType: args[9] || 'Unknown',
+      healthRemaining: parseFloat(args[10])
     };
 
     logParser.eventStore.session[args[3]] = data;
-
     logParser.emit('DEPLOYABLE_DAMAGED', data);
   }
 };

--- a/squad-server/plugins/cbl-info.js
+++ b/squad-server/plugins/cbl-info.js
@@ -1,5 +1,4 @@
 import GraphQLRequest from 'graphql-request';
-
 import DiscordBasePlugin from './discord-base-plugin.js';
 
 const { request, gql } = GraphQLRequest;
@@ -38,7 +37,6 @@ export default class CBLInfo extends DiscordBasePlugin {
 
   constructor(server, options, connectors) {
     super(server, options, connectors);
-
     this.onPlayerConnected = this.onPlayerConnected.bind(this);
   }
 
@@ -68,7 +66,6 @@ export default class CBLInfo extends DiscordBasePlugin {
               lastRefreshedReputationRank
               activeBans: bans(orderBy: "created", orderDirection: DESC, expired: false) {
                 edges {
-                  cursor
                   node {
                     id
                   }
@@ -76,7 +73,6 @@ export default class CBLInfo extends DiscordBasePlugin {
               }
               expiredBans: bans(orderBy: "created", orderDirection: DESC, expired: true) {
                 edges {
-                  cursor
                   node {
                     id
                   }
@@ -118,10 +114,18 @@ export default class CBLInfo extends DiscordBasePlugin {
           description: `[${info.player.name}](https://communitybanlist.com/search/${info.player.steamID}) has ${data.steamUser.reputationPoints} reputation points on the Community Ban List and is therefore a potentially harmful player.`,
           fields: [
             {
+              name: 'Steam ID',
+              value: `[${info.player.steamID}](https://steamcommunity.com/profiles/${info.player.steamID})`,
+              inline: true
+            },
+            {
+              name: 'EOS ID',
+              value: info.player.eosID || 'Unknown',
+              inline: true
+            },
+            {
               name: 'Reputation Points',
-              value: `${data.steamUser.reputationPoints} (${
-                data.steamUser.reputationPointsMonthChange || 0
-              } from this month)`,
+              value: `${data.steamUser.reputationPoints}`,
               inline: true
             },
             {
@@ -155,7 +159,7 @@ export default class CBLInfo extends DiscordBasePlugin {
     } catch (err) {
       this.verbose(
         1,
-        `Failed to fetch Community Ban List data for player ${info.name} (Steam ID: ${info.steamID}): `,
+        `Failed to fetch Community Ban List data for player ${info.player?.name} (Steam ID: ${info.player?.steamID}):`,
         err
       );
     }

--- a/squad-server/plugins/discord-server-status.js
+++ b/squad-server/plugins/discord-server-status.js
@@ -1,12 +1,10 @@
 import tinygradient from 'tinygradient';
-
 import { COPYRIGHT_MESSAGE } from '../utils/constants.js';
-
 import DiscordBaseMessageUpdater from './discord-base-message-updater.js';
 
 export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
   static get description() {
-    return 'The <code>DiscordServerStatus</code> plugin can be used to get the server status in Discord.';
+    return 'Enhanced DiscordServerStatus with recovery from map name messages and periodic announcements.';
   }
 
   static get defaultEnabled() {
@@ -23,110 +21,221 @@ export default class DiscordServerStatus extends DiscordBaseMessageUpdater {
       },
       updateInterval: {
         required: false,
-        description: 'How frequently to update the time in Discord.',
+        description: 'How frequently to update the message.',
         default: 60 * 1000
       },
       setBotStatus: {
         required: false,
-        description: "Whether to update the bot's status with server information.",
+        description: "Whether to update the bot's status.",
         default: true
+      },
+      channelId: {
+        required: true,
+        description: 'Channel to fetch and send layer info.',
+        default: null
+      },
+      layerTagId: {
+        required: false,
+        description: 'Optional tag to distinguish this server in layer messages.',
+        default: 'DEFAULT'
+      },
+      resendIntervalMinutes: {
+        required: false,
+        description: 'How often (in minutes) to resend the current map/layer to Discord.',
+        default: 5
       }
     };
   }
 
   constructor(server, options, connectors) {
     super(server, options, connectors);
-
+    this.currentLayerInfo = null;
     this.updateMessages = this.updateMessages.bind(this);
     this.updateStatus = this.updateStatus.bind(this);
+    this.onNewGame = this.onNewGame.bind(this);
+    this.repeatLayerAnnouncement = this.repeatLayerAnnouncement.bind(this);
   }
 
   async mount() {
     await super.mount();
+    this.server.on('NEW_GAME', this.onNewGame);
     this.updateInterval = setInterval(this.updateMessages, this.options.updateInterval);
     this.updateStatusInterval = setInterval(this.updateStatus, this.options.updateInterval);
+    this.repeatLayerInterval = setInterval(this.repeatLayerAnnouncement, this.options.resendIntervalMinutes * 60 * 1000);
+    await this.tryRecoverLayerFromDiscord();
   }
 
   async unmount() {
     await super.unmount();
+    this.server.removeEventListener('NEW_GAME', this.onNewGame);
     clearInterval(this.updateInterval);
     clearInterval(this.updateStatusInterval);
+    clearInterval(this.repeatLayerInterval);
+  }
+
+  async tryRecoverLayerFromDiscord() {
+    try {
+      const channel = await this.options.discordClient.channels.fetch(this.options.channelId);
+      const messages = await channel.messages.fetch({ limit: 10 });
+      const marker = `[SQUADJS-LAYER][${this.options.layerTagId}]:`;
+
+      for (const msg of messages.values()) {
+        if (!msg.content.startsWith(marker)) continue;
+
+        const raw = msg.content.replace(marker, '').trim();
+        let name = raw;
+        let id = this.slugify(raw);
+        let factions = [];
+
+        // Format 1: GE_VO_AlBasrah_Invasion_v2 GE_ussf GE_hez
+        if (raw.match(/\s/)) {
+          const [map, faction1, faction2] = raw.split(/\s+/);
+          name = map;
+          id = this.slugify(name);
+          if (faction1 && faction2) {
+            factions = [faction1.replace(/^GE_/, ''), faction2.replace(/^GE_/, '')];
+          }
+        }
+
+        // Format 2: GE_Anvil_Invasion_v1_USSF-KG
+        else if (raw.includes('_') && raw.includes('-')) {
+          const match = raw.match(/(.+?)_([A-Za-z]+)-([A-Za-z]+)$/);
+          if (match) {
+            name = match[1];
+            id = this.slugify(name);
+            factions = [match[2], match[3]];
+          }
+        }
+
+        this.currentLayerInfo = { name, id, factions };
+        break;
+      }
+    } catch (err) {
+      console.warn('Layer recovery from Discord failed:', err);
+    }
+  }
+
+  async onNewGame(info) {
+    this.currentLayerInfo = {
+      name: info.layer?.name || info.layerClassname || 'Unknown Layer',
+      id: info.layer?.id || this.slugify(info.layer?.name || info.layerClassname || 'Unknown'),
+      factions: info.layer?.factions || []
+    };
+
+    try {
+      const channel = await this.options.discordClient.channels.fetch(this.options.channelId);
+      await channel.send(`[SQUADJS-LAYER][${this.options.layerTagId}]: ${this.currentLayerInfo.name}`);
+    } catch (err) {
+      console.warn('Failed to send layer name to Discord channel:', err);
+    }
+  }
+
+  async repeatLayerAnnouncement() {
+    if (!this.currentLayerInfo?.name) return;
+
+    try {
+      const channel = await this.options.discordClient.channels.fetch(this.options.channelId);
+      await channel.send(`[SQUADJS-LAYER][${this.options.layerTagId}]: ${this.currentLayerInfo.name}`);
+    } catch (err) {
+      console.warn('Failed to resend layer name to Discord channel:', err);
+    }
+  }
+
+  slugify(text) {
+    return text.toString().toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
   }
 
   async generateMessage() {
-    // Set player embed field.
-    let players = '';
+    const a2sPlayerCount = this.server.a2sPlayerCount ?? 0;
+    const publicQueue = this.server.publicQueue ?? 0;
+    const reserveQueue = this.server.reserveQueue ?? 0;
+    const publicSlots = this.server.publicSlots ?? 100;
+    const reserveSlots = this.server.reserveSlots ?? 0;
 
-    players += `${this.server.a2sPlayerCount}`;
-    if (this.server.publicQueue + this.server.reserveQueue > 0)
-      players += ` (+${this.server.publicQueue + this.server.reserveQueue})`;
+    let players = `${a2sPlayerCount}`;
+    const totalQueue = publicQueue + reserveQueue;
+    if (totalQueue > 0) players += ` (+${totalQueue})`;
+    players += ` / ${publicSlots}`;
+    if (reserveSlots > 0) players += ` (+${reserveSlots})`;
 
-    players += ` / ${this.server.publicSlots}`;
-    if (this.server.reserveSlots > 0) players += ` (+${this.server.reserveSlots})`;
+    const fallbackLayer = (await this.server.rcon.getCurrentMap())?.layer || 'Unknown';
+    const layerName = this.currentLayerInfo?.name || fallbackLayer;
 
-    const layerName = this.server.currentLayer
-      ? this.server.currentLayer.name
-      : (await this.server.rcon.getCurrentMap()).layer;
-
-    // Clamp the ratio between 0 and 1 to avoid tinygradient errors.
-    const ratio = this.server.a2sPlayerCount / (this.server.publicSlots + this.server.reserveSlots);
-    const clampedRatio = Math.min(1, Math.max(0, ratio));
-
-    // Set gradient embed color.
+    const ratio = Math.min(1, Math.max(0, a2sPlayerCount / (publicSlots + reserveSlots || 1)));
     const color = parseInt(
       tinygradient([
         { color: '#ff0000', pos: 0 },
         { color: '#ffff00', pos: 0.5 },
         { color: '#00ff00', pos: 1 }
-      ])
-        .rgbAt(clampedRatio)
-        .toHex(),
+      ]).rgbAt(ratio).toHex(),
       16
     );
 
-    const embedobj = {
-      title: this.server.serverName,
-      fields: [
-        {
-          name: 'Players',
-          value: players
-        },
-        {
-          name: 'Current Layer',
-          value: `\`\`\`${layerName || 'Unknown'}\`\`\``,
-          inline: true
-        },
-        {
-          name: 'Next Layer',
-          value: `\`\`\`${
-            this.server.nextLayer?.name ||
-            (this.server.nextLayerToBeVoted ? 'To be voted' : 'Unknown')
-          }\`\`\``,
-          inline: true
-        }
-      ],
-      color: color,
-      footer: { text: COPYRIGHT_MESSAGE },
-      timestamp: new Date(),
-      // Dont use CDN for images, use raw.githubusercontent.com.
-      // Also not updated for 8.x properly.
-      image: {
-        url: this.server.currentLayer
-          ? `https://raw.githubusercontent.com/Squad-Wiki/squad-wiki-pipeline-map-data/master/completed_output/_Current%20Version/images/${this.server.currentLayer.layerid}.jpg`
-          : undefined
-      }
-    };
+    const factions = this.currentLayerInfo?.factions || [];
+    const factionsText = factions.length === 2 ? `${factions[0]} vs ${factions[1]}` : 'Unknown';
 
-    return { embeds: [embedobj] };
+    let imageUrl;
+    if (this.currentLayerInfo?.id) {
+      imageUrl = `https://raw.githubusercontent.com/Squad-Wiki/squad-wiki-pipeline-map-data/master/completed_output/_Current%20Version/images/${this.currentLayerInfo.id}.jpg`;
+    } else if (this.currentLayerInfo?.name) {
+      const fallbackName = this.slugify(this.currentLayerInfo.name);
+      imageUrl = `https://raw.githubusercontent.com/Squad-Wiki/squad-wiki-pipeline-map-data/master/completed_output/_Current%20Version/images/${fallbackName}.jpg`;
+    }
+
+    return {
+      embeds: [
+        {
+          title: this.server.serverName || 'Squad Server',
+          fields: [
+            {
+              name: 'Players',
+              value: players,
+              inline: true
+            },
+            {
+              name: 'Queue',
+              value: `Public: ${publicQueue}\nReserve: ${reserveQueue}`,
+              inline: true
+            },
+            {
+              name: 'Current Layer',
+              value: `\u200B\n\u200B\n\u200B\n\`\`\`${layerName}\`\`\``,
+              inline: true
+            },
+            {
+              name: 'Factions',
+              value: `\`\`\`${factionsText}\`\`\``,
+              inline: true
+            },
+            {
+              name: 'Next Layer',
+              value: `\`\`\`${
+                this.server.nextLayer?.name ||
+                (this.server.nextLayerToBeVoted ? 'To be voted' : 'Unknown')
+              }\`\`\``,
+              inline: true
+            }
+          ],
+          color: color,
+          footer: { text: COPYRIGHT_MESSAGE },
+          timestamp: new Date(),
+          image: imageUrl ? { url: imageUrl } : undefined
+        }
+      ]
+    };
   }
 
   async updateStatus() {
     if (!this.options.setBotStatus) return;
 
+    const a2sPlayerCount = this.server.a2sPlayerCount ?? 0;
+    const publicQueue = this.server.publicQueue ?? 0;
+    const reserveQueue = this.server.reserveQueue ?? 0;
+    const publicSlots = this.server.publicSlots ?? 100;
+    const layerName = this.currentLayerInfo?.name || 'Unknown';
+
     await this.options.discordClient.user.setActivity(
-      `(${this.server.a2sPlayerCount}/${this.server.publicSlots}) ${
-        this.server.currentLayer?.name || 'Unknown'
-      }`,
+      `(${a2sPlayerCount}/${publicSlots}) Q:${publicQueue}/${reserveQueue} ${layerName}`,
       { type: 4 }
     );
   }


### PR DESCRIPTION
ive Updated the Server Status in Discord , & FOB Explosions plugins to both Support GE MOD 

the discord Status bot now has 
<img width="442" height="370" alt="image" src="https://github.com/user-attachments/assets/4f1e9fef-7505-4881-bdde-3ee2892ce6b8" />
shows as follows , 

it will send a specific line in a specified channel the name of the map so incase the you restart SQuadJS it wont Show UNKNOWN maps anymore , its not perfect but it gets the job done 95% of the times , and ive included 

`
      "layerTagId": "SERVER2",
      "resendIntervalMinutes": 10,`

so u can change the tag if you have more than one server so it wont interfere with another server status , and the interval is there.

the FoB EXP Plugin 
it has 2 formats :

1. Just the name , No SteamId no EOSId  
`[2025.07.19-16.46.53:928][470]LogSquadTrace: [DedicatedServer]TakeDamage(): GE_RGF_Hab_C_2145023677: 200.00 damage attempt by causer BP_Deployable_IED_C_2144631956 instigator Salim_iQ54 with damage type SQDamageType_Thermite health remaining 500.00`

2. Full INFO , Name , SteamID, EOSID ...etc 

`[2025.07.19-16.47.18:333][518]LogSquadTrace: [DedicatedServer]TakeDamage(): GE_INS_Hab_C_2146655971: 1.15 damage taken by causer BP_M67Frag_C_2146602925 instigator DroolJoker (Online IDs: EOS: 000227fa81db47e8878055432678582a steam: 76561197966529876) health remaining 286.70`

its very stable so far and very reliable but it sometimes at each hit it makes kind of a spam and needs more improvments , its a very good log to see whos destroying radios with anything except for a **SHOVEL !!!**


<img width="721" height="942" alt="image" src="https://github.com/user-attachments/assets/2d936bf0-7b30-4772-a2cb-edbd63b14a54" />

<img width="680" height="962" alt="image" src="https://github.com/user-attachments/assets/202141be-96f1-4203-a6f5-64ff4c2a5fbc" />

.
>
>
>

ive forgot to add a little edit ive made to the cbl , now it shows steam ID , eos id ..etc

<img width="720" height="616" alt="image" src="https://github.com/user-attachments/assets/5db57678-cdb7-4a46-a8b8-3fc987889e43" />
