### PR TITLE
Fix player-disconnected log regex for 9.0

### DIFF
--- a/squad-server/log-parser/player-disconnected.js
+++ b/squad-server/log-parser/player-disconnected.js
@@ -1,6 +1,6 @@
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogNet: UChannel::Close: Sending CloseBunch\. ChIndex == [0-9]+\. Name: \[UChannel\] ChIndex: [0-9]+, Closing: [0-9]+ \[UNetConnection\] RemoteAddr: ([\d.]+):[\d]+, Name: EOSIpNetConnection_[0-9]+, Driver: GameNetDriver EOSNetDriver_[0-9]+, IsServer: YES, PC: ([^ ]+PlayerController(?:|.+)_C_[0-9]+), Owner: [^ ]+PlayerController(?:|.+)_C_[0-9]+, UniqueId: RedpointEOS:([\d\w]+)/,
+    /^\[([\d.:-]+)]\[([ \d]*)]LogNet: UChannel::Close: Sending CloseBunch\..+RemoteAddr: ([\d.]+).+PC: (\w+PlayerController(?:|.+)_C_\d+),.+UniqueId: RedpointEOS:([\d\w]+)/,
   onMatch: (args, logParser) => {
     const data = {
       raw: args[0],


### PR DESCRIPTION
Squad 9.0 did some changes in the log message.

Only require the things we care about so it is more robust against future changes.