### PR TITLE
Add PLAYER_PREFIX event

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -224,6 +224,15 @@ export default class SquadServer extends EventEmitter {
       this.emit('PLAYER_CONNECTED', data);
     });
 
+    this.logParser.on('PLAYER_PREFIX', async (data) => {
+      data.player = await this.getPlayerByEOSID(data.eosID, true);
+      if (data.player && data.player.suffix) {
+        const prefixLen = data.player.name.length - data.player.suffix.length - 1;
+        data.player.prefix = data.player.name.substr(0, prefixLen);
+        this.emit('PLAYER_PREFIX', data);
+      }
+    });
+
     this.logParser.on('PLAYER_DISCONNECTED', async (data) => {
       data.player = await this.getPlayerByEOSID(data.eosID);
 

--- a/squad-server/log-parser/player-prefix.js
+++ b/squad-server/log-parser/player-prefix.js
@@ -1,0 +1,22 @@
+import { iterateIDs, lowerID } from 'core/id-parser';
+
+export default {
+  regex:
+  /^\[([\d.:-]+)\]\[([ \d]*)\]LogSquadCommon: SQCommonStatics Check Permissions, UniqueId:(\w+)/,
+  onMatch: (args, logParser) => {
+    const eosID = args[3];
+    const player = logParser.eventStore.players[eosID];
+    if (!player || !player.playerSuffix || player.seen)
+      return;
+    player.seen = true;
+
+    const data = {
+      raw: args[0],
+      time: args[1],
+      chainID: +args[2],
+      ...player
+    };
+
+    logParser.emit('PLAYER_PREFIX', data);
+  }
+};


### PR DESCRIPTION
The player prefix, a.k.a clan tag, is a message sent by the game client rather late in the map loading sequence. It is therefore not part of the PLAYER_CONNECTED event.

You can see this message being received in the game log directly by increasing verbosity. But most server owners don't want to change log verbosity.

This log parser therefore looks for other log lines, specifically "Check Permissions", that occur before and after the hidden prefix log line. By matching these to the known sequence we can determine when prefix is avaialable.

After this event, we know the player name contains both prefix and suffix. We can thus reliably determine the player prefix.