### PR TITLE
fix(team-randomizer): add safety improvements

### DIFF
--- a/squad-server/plugins/team-randomizer.js
+++ b/squad-server/plugins/team-randomizer.js
@@ -9,7 +9,7 @@ export default class TeamRandomizer extends BasePlugin {
   }
 
   static get defaultEnabled() {
-    return true;
+    return false;
   }
 
   static get optionsSpecification() {
@@ -38,28 +38,43 @@ export default class TeamRandomizer extends BasePlugin {
 
   async onChatCommand(info) {
     if (info.chat !== 'ChatAdmin') return;
-
-    const players = this.server.players.slice(0);
-
-    let currentIndex = players.length;
-    let temporaryValue;
-    let randomIndex;
-
-    while (currentIndex !== 0) {
-      randomIndex = Math.floor(Math.random() * currentIndex);
-      currentIndex -= 1;
-
-      temporaryValue = players[currentIndex];
-      players[currentIndex] = players[randomIndex];
-      players[randomIndex] = temporaryValue;
+    if (this.randomizing) {
+      await this.server.rcon.warn(info.player.eosID, 'Randomization already in progress.');
+      return;
     }
+    this.randomizing = true;
 
-    let team = '1';
+    try {
+      const players = this.server.players.slice(0);
 
-    for (const player of players) {
-      if (player.teamID !== team) await this.server.rcon.switchTeam(player.eosID);
+      let currentIndex = players.length;
 
-      team = team === '1' ? '2' : '1';
+      while (currentIndex !== 0) {
+        const randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex -= 1;
+        [players[currentIndex], players[randomIndex]] = [players[randomIndex], players[currentIndex]];
+      }
+
+      await this.server.rcon.broadcast('Teams are being randomized, please wait.');
+
+      let team = '1';
+      let switched = 0;
+
+      for (const player of players) {
+        if (player.teamID !== team) {
+          try {
+            await this.server.rcon.switchTeam(player.eosID);
+            switched++;
+          } catch (error) {
+            this.verbose(1, `Failed to switch ${player.name}: ${error.message}`);
+          }
+        }
+        team = team === '1' ? '2' : '1';
+      }
+
+      await this.server.rcon.warn(info.player.eosID, `Randomization complete. ${switched} player(s) switched.`);
+    } finally {
+      this.randomizing = false;
     }
   }
 }

--- a/squad-server/plugins/team-randomizer.js
+++ b/squad-server/plugins/team-randomizer.js
@@ -52,7 +52,10 @@ export default class TeamRandomizer extends BasePlugin {
       while (currentIndex !== 0) {
         const randomIndex = Math.floor(Math.random() * currentIndex);
         currentIndex -= 1;
-        [players[currentIndex], players[randomIndex]] = [players[randomIndex], players[currentIndex]];
+        [players[currentIndex], players[randomIndex]] = [
+          players[randomIndex],
+          players[currentIndex]
+        ];
       }
 
       await this.server.rcon.broadcast('Teams are being randomized, please wait.');
@@ -72,7 +75,10 @@ export default class TeamRandomizer extends BasePlugin {
         team = team === '1' ? '2' : '1';
       }
 
-      await this.server.rcon.warn(info.player.eosID, `Randomization complete. ${switched} player(s) switched.`);
+      await this.server.rcon.warn(
+        info.player.eosID,
+        `Randomization complete. ${switched} player(s) switched.`
+      );
     } finally {
       this.randomizing = false;
     }


### PR DESCRIPTION
## Summary

Several safety and UX issues in `TeamRandomizer` that affect production servers:

- **Disabled by default** — changed `defaultEnabled` from `true` to `false`. This is a destructive, irreversible-during-round operation; it shouldn't be on without explicit opt-in.
- **Re-entrancy guard** — concurrent `!randomize` calls from multiple admins would run simultaneously and clobber each other. Added a `this.randomizing` flag with `try/finally` to ensure it always resets even on error.
- **Error handling per player** — the original loop had no try/catch; a single failed `switchTeam` RCON call would abort mid-shuffle, leaving teams in a partially-randomized state. Now each switch is caught individually, logs the failure, and continues.
- **Player broadcast** — players were silently moved to different teams with no explanation. Added an `AdminBroadcast` before switching starts.
- **Admin feedback** — the admin who ran the command got no confirmation. Added a `warn` on completion with the count of players switched.
- **Shuffle cleanup** — removed the unnecessary `temporaryValue` temp variable; replaced with destructuring swap.

## Test plan

- [ ] Run `!randomize` in admin chat — confirm broadcast fires, teams are shuffled, admin receives completion message
- [ ] Run `!randomize` twice simultaneously — confirm second call is rejected with "already in progress" message
- [ ] Verify plugin is opt-in by default (not enabled in generated config)