### PR TITLE
fix: regex for player-connected log parsing for modded layers

### DIFF
--- a/squad-server/log-parser/player-connected.js
+++ b/squad-server/log-parser/player-connected.js
@@ -2,7 +2,7 @@ import { iterateIDs, lowerID } from 'core/id-parser';
 
 export default {
   regex:
-    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: BP_PlayerController(?:|.+)_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
+    /^\[([0-9.:-]+)]\[([ 0-9]*)]LogSquad: PostLogin: NewPlayer: .*?BP_PlayerController(?:|.+)_C .+PersistentLevel\.([^\s]+) \(IP: ([\d.]+) \| Online IDs:([^)|]+)\)/,
   onMatch: (args, logParser) => {
     const IDs = {};
     iterateIDs(args[5]).forEach((platform, id) => {


### PR DESCRIPTION
This log parser breaks with the steel division mod. 

Normally (with SAT):
`... LogSquad: PostLogin: NewPlayer: BP_PlayerController_AdminTools_C /SquadAdminTools/Maps/MapInitializer/Gameplay_Layers/VoiceConnect_Init.VoiceConnect_Init:PersistentLevel.BP_PlayerController_AdminTools_C_2147472511 ...`

But the pattern holds up with other mods (only tested with SATCOM and SPM)

With Steel Division:
`... LogSquad: PostLogin: NewPlayer: SD_BP_PlayerController_C /Steel_Division/Maps/Narva/Gameplay_Layer/SDL_Narva_Invasion_v2_D.SDL_Narva_Invasion_v2_D:PersistentLevel.SD_BP_PlayerController_C_2143786989 ...`

The thinking here is to match anything or nothing attached to the front of BP_PlayerContoller. Tested on live server with SD and found to be working.